### PR TITLE
Add Petri-net CPU assignment inhibition module

### DIFF
--- a/sys/kern/petri_global_net.c
+++ b/sys/kern/petri_global_net.c
@@ -47,7 +47,7 @@ const int base_resource_inhibition_matrix[CPU_BASE_PLACES][CPU_BASE_TRANSITIONS]
 	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-	{ 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0}
+	{ 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0}
 };
 
 const char *transitions_names[] = {
@@ -343,6 +343,15 @@ resource_cpu_is_suspended(int cpu)
 		return (0);
 	return (resource_net.mark[PLACE_SUSPENDED +
 	    (cpu * CPU_BASE_PLACES)] != 0);
+}
+
+void
+resource_wakeup_cpu(int cpu, struct thread *td, char *trigger)
+{
+	if (!resource_cpu_is_suspended(cpu))
+		return;
+	resource_fire_net(trigger, td, (cpu * CPU_BASE_TRANSITIONS) +
+	    TRAN_WAKEUP_PROC);
 }
 
 void resource_expulse_thread(struct thread *td, int flags) {

--- a/sys/kern/petri_global_net.c
+++ b/sys/kern/petri_global_net.c
@@ -387,7 +387,7 @@ sysctl_sched_petri_cpu_toggle(SYSCTL_HANDLER_ARGS)
 	if (cpu <= 0 || cpu >= CPU_NUMBER)
 		return (EINVAL);
 
-	toggle_active_cpu(cpu);
+	sched_petri_toggle_cpu(cpu);
 	return (0);
 }
 

--- a/sys/kern/petri_global_net.c
+++ b/sys/kern/petri_global_net.c
@@ -47,7 +47,7 @@ const int base_resource_inhibition_matrix[CPU_BASE_PLACES][CPU_BASE_TRANSITIONS]
 	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-	{ 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0}
+	{ 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0}
 };
 
 const char *transitions_names[] = {
@@ -207,6 +207,10 @@ int get_place_tokens_qty(int place_index)
 
 void resource_fire_net(char *trigger, struct thread *pt, int transition_index)
 {
+	if (transition_index < 0 || transition_index >= CPU_NUMBER_TRANSITION)
+		panic("petri-net invalid transition: %d from %s",
+		    transition_index, trigger);
+
 	if(pt) {
 		int automatic_transition;
 
@@ -225,11 +229,15 @@ void resource_fire_net(char *trigger, struct thread *pt, int transition_index)
 		}
 		else {
 			if(print_enabled) {
-				// TODO: Add a kernel panic exit here. We don't care about post error transitions
-				printf("!! %s - Non sensitized transition: %2d - Thread %2d - CPU %2d - FROM %s!!\n", transitions_names[transition_index], transition_index, pt->td_tid, PCPU_GET(cpuid), trigger);
+				printf("!! %s - Non sensitized transition: %2d - Thread %2d - CPU %2d - FROM %s - td_flags %#x - td_pinned %d - td_lastcpu %d!!\n",
+				    transitions_names[transition_index],
+				    transition_index, pt->td_tid, PCPU_GET(cpuid),
+				    trigger, pt->td_flags, pt->td_pinned,
+				    pt->td_lastcpu);
 				print_detailed_places();
-				transitions_to_print = 0;
 			}
+			panic("petri-net non-sensitized transition: %s from %s",
+			    transitions_names[transition_index], trigger);
 		}
 	}
 
@@ -296,12 +304,14 @@ int transition_is_sensitized(int transition_index)
 int resource_choose_cpu(struct thread* td)
 {
 	//First we need to know which of the cpu queues is sensitized
+	int cpu;
 	int transition_index;
 	int best = NOCPU;
 
 	if (
 		td->td_lastcpu != NOCPU &&
 		THREAD_CAN_SCHED(td, td->td_lastcpu) &&
+		!resource_cpu_is_suspended(td->td_lastcpu) &&
 		transition_is_sensitized(td->td_lastcpu * CPU_BASE_TRANSITIONS)
 	) {
 		best = td->td_lastcpu;
@@ -310,17 +320,29 @@ int resource_choose_cpu(struct thread* td)
 
 	//Only check for transitions of addtoqueue
 	for (transition_index = TRAN_ADDTOQUEUE; transition_index < CPU_NUMBER_TRANSITION-4; transition_index += CPU_BASE_TRANSITIONS) {
+		cpu = transition_index / CPU_BASE_TRANSITIONS;
 		if (transition_is_sensitized(transition_index)) {
-			if (!THREAD_CAN_SCHED(td, (transition_index / CPU_BASE_TRANSITIONS)))
+			if (resource_cpu_is_suspended(cpu))
+				continue;
+			if (!THREAD_CAN_SCHED(td, cpu))
 				continue;
 			else {
-				best = (transition_index / CPU_BASE_TRANSITIONS);
+				best = cpu;
 				break;
 			}
 		}
 	}
 
 	return best;
+}
+
+int
+resource_cpu_is_suspended(int cpu)
+{
+	if (cpu < 0 || cpu >= CPU_NUMBER)
+		return (0);
+	return (resource_net.mark[PLACE_SUSPENDED +
+	    (cpu * CPU_BASE_PLACES)] != 0);
 }
 
 void resource_expulse_thread(struct thread *td, int flags) {

--- a/sys/kern/petri_global_net.c
+++ b/sys/kern/petri_global_net.c
@@ -9,9 +9,13 @@
  */
 
 #include <sys/types.h>
+#include <sys/errno.h>
 #include <sys/param.h>
 #include <sys/cpuset.h>
+#include <sys/kernel.h>
 #include <sys/smp.h>
+#include <sys/sysctl.h>
+#include <sys/systm.h>
 #include <sys/time.h>
 #include <sys/sched_petri.h>
 
@@ -103,6 +107,14 @@ const int hierarchical_corresponse[] = {
 
 static void resource_fire_single_transition(struct thread *pt, int transition_index);
 static int get_automatic_transitions_sensitized(void);
+static int sysctl_sched_petri_cpu_toggle(SYSCTL_HANDLER_ARGS);
+
+SYSCTL_NODE(_kern, OID_AUTO, sched_petri, CTLFLAG_RW | CTLFLAG_MPSAFE, 0,
+    "Petri-net scheduler controls");
+SYSCTL_PROC(_kern_sched_petri, OID_AUTO, cpu_toggle,
+    CTLTYPE_INT | CTLFLAG_RW | CTLFLAG_MPSAFE, 0, 0,
+    sysctl_sched_petri_cpu_toggle, "I",
+    "Toggle the Petri-net scheduler state for a CPU by id");
 
 void init_resource_net()
 {
@@ -360,6 +372,23 @@ void print_detailed_places() {
 
 void set_print_transition(int number_transitions) {
 	transitions_to_print = number_transitions;
+}
+
+static int
+sysctl_sched_petri_cpu_toggle(SYSCTL_HANDLER_ARGS)
+{
+	int cpu;
+	int error;
+
+	cpu = -1;
+	error = sysctl_handle_int(oidp, &cpu, 0, req);
+	if (error != 0 || req->newptr == NULL)
+		return (error);
+	if (cpu <= 0 || cpu >= CPU_NUMBER)
+		return (EINVAL);
+
+	toggle_active_cpu(cpu);
+	return (0);
 }
 
 void toggle_active_cpu(int cpu) {

--- a/sys/kern/petri_global_net.c
+++ b/sys/kern/petri_global_net.c
@@ -28,36 +28,39 @@ struct petri_cpu_resource_net resource_net;
 
 const int base_resource_matrix[CPU_BASE_PLACES][CPU_BASE_TRANSITIONS] = {
 	/*Base matrix */
-	{ 1, 0,-1, 0, 0, 0, 0,-1, 0},
-	{ 1,-1, 0, 0, 0, 0, 0,-1,-1},
-	{ 0,-1, 0, 0, 1, 1,-1, 0, 0},
-	{ 0, 1,-1,-1, 0, 0, 1, 0, 0},
-	{ 0, 0, 1, 1,-1,-1, 0, 0, 0}
+	{ 1, 0,-1, 0, 0, 0, 0, 0,-1, 0, 0, 0},
+	{ 1,-1, 0, 0, 0, 0, 0, 0,-1,-1, 0, 0},
+	{ 0,-1, 0, 0,-1, 1, 1,-1, 0, 0, 0, 0},
+	{ 0, 1,-1,-1, 1, 0, 0, 1, 0, 0, 0, 0},
+	{ 0, 0, 1, 1, 0,-1,-1, 0, 0, 0, 0, 0},
+	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,-1}
 };
 
 const int base_resource_inhibition_matrix[CPU_BASE_PLACES][CPU_BASE_TRANSITIONS] = {
 	/*Base inhibition matrix */
-	{ 0, 0, 0, 1, 0, 0, 0, 0, 1},
-	{ 0, 0, 0, 0, 0, 0, 0, 0, 0},
-	{ 0, 0, 0, 0, 0, 0, 0, 0, 0},
-	{ 0, 0, 0, 0, 0, 0, 0, 0, 0},
-	{ 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	{ 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0},
+	{ 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0},
+	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+	{ 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0}
 };
 
 const char *transitions_names[] = {
-	"ADDTOQUEUE_P0", "UNQUEUE_P0", "EXEC_P0", "EXEC_EMPTY_P0", "RETURN_VOL_P0", "RETURN_INVOL_P0", "FROM_GLOBAL_CPU_P0", "REMOVE_QUEUE_P0", "REMOVE_EMPTY_QUEUE_P0",
-	"ADDTOQUEUE_P1", "UNQUEUE_P1", "EXEC_P1", "EXEC_EMPTY_P1", "RETURN_VOL_P1", "RETURN_INVOL_P1", "FROM_GLOBAL_CPU_P1", "REMOVE_QUEUE_P1", "REMOVE_EMPTY_QUEUE_P1",
-	"ADDTOQUEUE_P2", "UNQUEUE_P2", "EXEC_P2", "EXEC_EMPTY_P2", "RETURN_VOL_P2", "RETURN_INVOL_P2", "FROM_GLOBAL_CPU_P2", "REMOVE_QUEUE_P2", "REMOVE_EMPTY_QUEUE_P2",
-	"ADDTOQUEUE_P3", "UNQUEUE_P3", "EXEC_P3", "EXEC_EMPTY_P3", "RETURN_VOL_P3", "RETURN_INVOL_P3", "FROM_GLOBAL_CPU_P3", "REMOVE_QUEUE_P3", "REMOVE_EMPTY_QUEUE_P3",
+	"ADDTOQUEUE_P0", "UNQUEUE_P0", "EXEC_P0", "EXEC_EMPTY_P0", "EXEC_IDLE_P0", "RETURN_VOL_P0", "RETURN_INVOL_P0", "FROM_GLOBAL_CPU_P0", "REMOVE_QUEUE_P0", "REMOVE_EMPTY_QUEUE_P0", "SUSPEND_PROC_P0", "WAKEUP_PROC_P0",
+	"ADDTOQUEUE_P1", "UNQUEUE_P1", "EXEC_P1", "EXEC_EMPTY_P1", "EXEC_IDLE_P1", "RETURN_VOL_P1", "RETURN_INVOL_P1", "FROM_GLOBAL_CPU_P1", "REMOVE_QUEUE_P1", "REMOVE_EMPTY_QUEUE_P1", "SUSPEND_PROC_P1", "WAKEUP_PROC_P1",
+	"ADDTOQUEUE_P2", "UNQUEUE_P2", "EXEC_P2", "EXEC_EMPTY_P2", "EXEC_IDLE_P2", "RETURN_VOL_P2", "RETURN_INVOL_P2", "FROM_GLOBAL_CPU_P2", "REMOVE_QUEUE_P2", "REMOVE_EMPTY_QUEUE_P2", "SUSPEND_PROC_P2", "WAKEUP_PROC_P2",
+	"ADDTOQUEUE_P3", "UNQUEUE_P3", "EXEC_P3", "EXEC_EMPTY_P3", "EXEC_IDLE_P3", "RETURN_VOL_P3", "RETURN_INVOL_P3", "FROM_GLOBAL_CPU_P3", "REMOVE_QUEUE_P3", "REMOVE_EMPTY_QUEUE_P3", "SUSPEND_PROC_P3", "WAKEUP_PROC_P3",
 	"REMOVE_GLOBAL_QUEUE", "START_SMP", "THROW", "QUEUE_GLOBAL"
 };
 
 const char *cpu_places_names[] = { "CANTQ", "QUEUE", "CPU", "TOEXEC", "EXECUTING", "SUSPENDED" };
 
-const int hierarchical_transitions[] = { 
+const int hierarchical_transitions[] = {
 	TRAN_ADDTOQUEUE,
 	TRAN_EXEC,
 	TRAN_EXEC_EMPTY,
+	TRAN_EXEC_IDLE,
 	TRAN_RETURN_INVOL,
 	TRAN_RETURN_VOL,
 	TRAN_REMOVE_QUEUE,
@@ -66,10 +69,11 @@ const int hierarchical_transitions[] = {
 	TRAN_REMOVE_GLOBAL_QUEUE
 };
 
-const int hierarchical_corresponse[] = { 
+const int hierarchical_corresponse[] = {
 	TRAN_ON_QUEUE,
 	TRAN_SET_RUNNING,
 	TRAN_SET_RUNNING,
+	TRAN_ON_QUEUE,
 	TRAN_SWITCH_OUT,
 	TRAN_TO_WAIT_CHANNEL,
 	TRAN_REMOVE,
@@ -79,20 +83,22 @@ const int hierarchical_corresponse[] = {
 };
 
 /* Extended matrix izq der                GLOBAL TRANSITIONS
-	{ 1, 0,-1, 0, 0, 0, 0,-1, 0},					  	       ,{ 0, 0, 0,-1, 0}
-	{ 1,-1, 0, 0, 0, 0, 0,-1,-1},					           ,{ 0, 0, 0, 0, 0}
-	{ 0,-1, 0, 0, 1, 1,-1, 0, 0},					           ,{ 0, 0, 0, 0, 0}
-	{ 0, 1,-1,-1, 0, 0, 1, 0, 0}					           ,{ 0,-1, 0, 0, 0}
-	{ 0, 0, 1, 1,-1,-1, 0, 0, 0}					           ,{ 0, 0, 0, 0, 0}
-						         { 1, 0,-1, 0, 0, 0, 0,-1, 0}, ,{ 0, 0, 0,-1, 0}
-							     { 1,-1, 0, 0, 0, 0, 0,-1,-1}, ,{ 0, 0, 0, 0, 0}
-							     { 0,-1, 0, 0, 1, 1,-1, 0, 0}, ,{ 0, 0, 0, 0, 0}
-							     { 0, 1,-1,-1, 0, 0, 1, 0, 0}  ,{ 0, 0, 0, 0, 0}
-							     { 0, 0, 1, 1,-1,-1, 0, 0, 0}  ,{ 0, 0, 0, 0, 0}
+	{ 1, 0,-1, 0, 0, 0, 0, 0,-1, 0, 0, 0 }, ,{ 0, 0,-1, 0}
+	{ 1,-1, 0, 0, 0, 0, 0, 0,-1,-1, 0, 0 }, ,{ 0, 0, 0, 0}
+	{ 0,-1, 0, 0,-1, 1, 1,-1, 0, 0, 0, 0 }, ,{ 0, 0, 0, 0}
+	{ 0, 1,-1,-1, 1, 0, 0, 1, 0, 0, 0, 0 }  ,{ 0, 0, 0, 0}
+	{ 0, 0, 1, 1, 0,-1,-1, 0, 0, 0, 0, 0 }  ,{ 0, 0, 0, 0}
+	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,-1 }  ,{ 0, 0, 0, 0}
+							     { 1, 0,-1, 0, 0, 0, 0, 0,-1, 0, 0, 0 }, ,{ 0, 0,-1, 0}
+							     { 1,-1, 0, 0, 0, 0, 0, 0,-1,-1, 0, 0 }, ,{ 0, 0, 0, 0}
+							     { 0,-1, 0, 0,-1, 1, 1,-1, 0, 0, 0, 0 }, ,{ 0, 0, 0, 0}
+							     { 0, 1,-1,-1, 1, 0, 0, 1, 0, 0, 0, 0 }, ,{ 0, 0, 0, 0}
+							     { 0, 0, 1, 1, 0,-1,-1, 0, 0, 0, 0, 0 }, ,{ 0, 0, 0, 0}
+							     { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,-1 }, ,{ 0, 0, 0, 0}
 	GLOBAL PLACE
-	{ 0, 0, 0, 0, 0, 0,-1, 0, 0} { 0, 0, 0, 0, 0, 0,-1, 0, 0}  ,{-1, 0, 0, 0, 1}
-	{ 0, 0, 0, 0, 0, 0, 0, 0, 0} { 0, 0, 0, 0, 0, 0, 0, 0, 0}  ,{ 0, 0,-1, 0, 0}
-	{ 0, 0, 0, 0, 0, 0, 0, 0, 0} { 0, 0, 0, 0, 0, 0, 0, 0, 0}  ,{ 0, 0, 1, 0, 0}
+	{ 0, 0, 0, 0, 0, 0, 0,-1, 0, 0, 0, 0 } 	{ 0, 0, 0, 0, 0, 0, 0,-1, 0, 0, 0, 0 }  	,{-1, 0, 0, 1}
+	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } 	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }  	,{ 0,-1, 0, 0}
+	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } 	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }  	,{ 0, 1, 0, 0}
 */
 
 static void resource_fire_single_transition(struct thread *pt, int transition_index);
@@ -182,6 +188,10 @@ void resource_get_sensitized()
 	}
 }
 
+int get_place_tokens_qty(int place_index)
+{
+	return resource_net.mark[place_index];
+}
 
 void resource_fire_net(char *trigger, struct thread *pt, int transition_index)
 {
@@ -350,4 +360,26 @@ void print_detailed_places() {
 
 void set_print_transition(int number_transitions) {
 	transitions_to_print = number_transitions;
+}
+
+void toggle_active_cpu(int cpu) {
+	if (cpu == 0) {
+		printf("toggle_active_cpu error - CPU 0 can not be turn off\n");
+		return;
+	}
+	else if (cpu >= CPU_NUMBER || cpu < 0) {
+		printf("toggle_active_cpu error - CPU %d does not exist\n", cpu);
+		return;
+	}
+
+	printf("TOGGLE ACTIVE/INACTIVE: CPU %d - Thread %2d\n", cpu, curthread->td_tid);
+	int tran_wakeup_index = (cpu*CPU_BASE_TRANSITIONS) + TRAN_WAKEUP_PROC;
+	int tran_suspend_index = (cpu*CPU_BASE_TRANSITIONS) + TRAN_SUSPEND_PROC;
+
+	if (transition_is_sensitized(tran_wakeup_index)){
+		resource_fire_net("toggle_active: wakeup", curthread, tran_wakeup_index);
+	}
+	else {
+		resource_fire_net("toggle_active: suspend", curthread, tran_suspend_index);
+	}
 }

--- a/sys/kern/sched_4bsd.c
+++ b/sys/kern/sched_4bsd.c
@@ -267,13 +267,13 @@ SYSCTL_INT(_kern_sched, OID_AUTO, followon, CTLFLAG_RW,
 
 SDT_PROVIDER_DEFINE(sched);
 
-SDT_PROBE_DEFINE3(sched, , , change__pri, "struct thread *", 
+SDT_PROBE_DEFINE3(sched, , , change__pri, "struct thread *",
     "struct proc *", "uint8_t");
-SDT_PROBE_DEFINE3(sched, , , dequeue, "struct thread *", 
+SDT_PROBE_DEFINE3(sched, , , dequeue, "struct thread *",
     "struct proc *", "void *");
-SDT_PROBE_DEFINE4(sched, , , enqueue, "struct thread *", 
+SDT_PROBE_DEFINE4(sched, , , enqueue, "struct thread *",
     "struct proc *", "void *", "int");
-SDT_PROBE_DEFINE4(sched, , , lend__pri, "struct thread *", 
+SDT_PROBE_DEFINE4(sched, , , lend__pri, "struct thread *",
     "struct proc *", "uint8_t", "struct thread *");
 SDT_PROBE_DEFINE2(sched, , , load__change, "int", "int");
 SDT_PROBE_DEFINE2(sched, , , off__cpu, "struct thread *",
@@ -858,7 +858,7 @@ sched_priority(struct thread *td, u_char prio)
 		KTR_POINT3(KTR_SCHED, "thread", sched_tdname(curthread),
 		    "lend prio", "prio:%d", td->td_priority, "new prio:%d",
 		    prio, KTR_ATTR_LINKED, sched_tdname(td));
-		SDT_PROBE4(sched, , , lend__pri, td, td->td_proc, prio, 
+		SDT_PROBE4(sched, , , lend__pri, td, td->td_proc, prio,
 		    curthread);
 	}
 	THREAD_LOCK_ASSERT(td, MA_OWNED);
@@ -1336,7 +1336,7 @@ sched_add(struct thread *td, int flags)
 	    sched_tdname(curthread));
 	KTR_POINT1(KTR_SCHED, "thread", sched_tdname(curthread), "wokeup",
 	    KTR_ATTR_LINKED, sched_tdname(td));
-	SDT_PROBE4(sched, , , enqueue, td, td->td_proc, NULL, 
+	SDT_PROBE4(sched, , , enqueue, td, td->td_proc, NULL,
 	    flags & SRQ_PREEMPTED);
 
 	/*
@@ -1350,7 +1350,7 @@ sched_add(struct thread *td, int flags)
 		else
 			thread_lock_set(td, &sched_lock);
 	}
-    TD_SET_RUNQ(td); 
+    TD_SET_RUNQ(td);
     /*
     * If SMP is started and the thread is pinned or otherwise limited to
     * a specific set of CPUs, queue the thread to a per-CPU run queue.
@@ -1439,7 +1439,7 @@ sched_add(struct thread *td, int flags)
 	    sched_tdname(curthread));
 	KTR_POINT1(KTR_SCHED, "thread", sched_tdname(curthread), "wokeup",
 	    KTR_ATTR_LINKED, sched_tdname(td));
-	SDT_PROBE4(sched, , , enqueue, td, td->td_proc, NULL, 
+	SDT_PROBE4(sched, , , enqueue, td, td->td_proc, NULL,
 	    flags & SRQ_PREEMPTED);
 
 	/*
@@ -1507,6 +1507,9 @@ sched_choose(void)
 {
 	struct thread *td;
 	struct runq *rq;
+	int is_cpu_suspended;
+
+	is_cpu_suspended = get_place_tokens_qty(PLACE_SUSPENDED + (PCPU_GET(cpuid)*CPU_BASE_PLACES));
 
 	mtx_assert(&sched_lock,  MA_OWNED);
 #ifdef SMP
@@ -1516,20 +1519,27 @@ sched_choose(void)
 	td = runq_choose_fuzz(&runq, runq_fuzz);
 	tdcpu = runq_choose(&runq_pcpu[PCPU_GET(cpuid)]);
 
-	if (td == NULL ||
-	    (tdcpu != NULL &&
-	     tdcpu->td_priority < td->td_priority)) {
+	if (is_cpu_suspended || td == NULL ||
+	    (tdcpu != NULL && tdcpu->td_priority < td->td_priority)) {
 		CTR2(KTR_RUNQ, "choosing td %p from pcpu runq %d", tdcpu,
-		     PCPU_GET(cpuid));
+		    PCPU_GET(cpuid));
 		td = tdcpu;
 		rq = &runq_pcpu[PCPU_GET(cpuid)];
 
 		if(td) {
-			resource_fire_net("sched_choose", td, TRAN_UNQUEUE + (PCPU_GET(cpuid)*CPU_BASE_TRANSITIONS));
+			resource_fire_net("sched_choose_1", td, TRAN_UNQUEUE + (PCPU_GET(cpuid)*CPU_BASE_TRANSITIONS));
+		}
+		else if (is_cpu_suspended){
+			if(PCPU_GET(idlethread)->td_frominh == 1) {
+				thread_petri_fire(PCPU_GET(idlethread), TRAN_WAKEUP);
+				PCPU_GET(idlethread)->td_frominh = 0;
+			}
+			resource_fire_net("sched_choose_4", PCPU_GET(idlethread), TRAN_EXEC_IDLE + (PCPU_GET(cpuid)*CPU_BASE_TRANSITIONS));
+			return (PCPU_GET(idlethread));
 		}
 	} else{
 		CTR1(KTR_RUNQ, "choosing td_sched %p from main runq", td);
-		resource_fire_net("sched_choose", td, TRAN_FROM_GLOBAL_CPU + (PCPU_GET(cpuid)*CPU_BASE_TRANSITIONS));
+		resource_fire_net("sched_choose_2", td, TRAN_FROM_GLOBAL_CPU + (PCPU_GET(cpuid)*CPU_BASE_TRANSITIONS));
 	}
 
 #else
@@ -1554,8 +1564,7 @@ sched_choose(void)
 		thread_petri_fire(PCPU_GET(idlethread), TRAN_WAKEUP);
 		PCPU_GET(idlethread)->td_frominh = 0;
 	}
-	resource_fire_net("sched_choose", PCPU_GET(idlethread), TRAN_QUEUE_GLOBAL);
-	resource_fire_net("sched_choose", PCPU_GET(idlethread), TRAN_FROM_GLOBAL_CPU + (PCPU_GET(cpuid)*CPU_BASE_TRANSITIONS));
+	resource_fire_net("sched_choose_3", PCPU_GET(idlethread), TRAN_EXEC_IDLE + (PCPU_GET(cpuid)*CPU_BASE_TRANSITIONS));
 	return (PCPU_GET(idlethread));
 }
 
@@ -1782,7 +1791,7 @@ sched_tdname(struct thread *td)
 		snprintf(ts->ts_name, sizeof(ts->ts_name),
 		    "%s tid %d", td->td_name, td->td_tid);
 	return (ts->ts_name);
-#else   
+#else
 	return (td->td_name);
 #endif
 }
@@ -1805,7 +1814,7 @@ sched_affinity(struct thread *td)
 	struct td_sched *ts;
 	int cpu;
 
-	THREAD_LOCK_ASSERT(td, MA_OWNED);	
+	THREAD_LOCK_ASSERT(td, MA_OWNED);
 
 	/*
 	 * Set the TSF_AFFINITY flag if there is at least one CPU this

--- a/sys/kern/sched_4bsd.c
+++ b/sys/kern/sched_4bsd.c
@@ -1305,6 +1305,14 @@ sched_petrinet_pickcpu(struct thread *td)
 	cpu = resource_choose_cpu(td);
 	return (cpu);
 }
+
+void
+sched_petri_toggle_cpu(int cpu)
+{
+	mtx_lock_spin(&sched_lock);
+	toggle_active_cpu(cpu);
+	mtx_unlock_spin(&sched_lock);
+}
 #endif
 
 void
@@ -1519,7 +1527,17 @@ sched_choose(void)
 	td = runq_choose_fuzz(&runq, runq_fuzz);
 	tdcpu = runq_choose(&runq_pcpu[PCPU_GET(cpuid)]);
 
-	if (is_cpu_suspended || td == NULL ||
+	if (is_cpu_suspended) {
+		if(PCPU_GET(idlethread)->td_frominh == 1) {
+			thread_petri_fire(PCPU_GET(idlethread), TRAN_WAKEUP);
+			PCPU_GET(idlethread)->td_frominh = 0;
+		}
+		resource_fire_net("sched_choose_4", PCPU_GET(idlethread),
+		    TRAN_EXEC_IDLE + (PCPU_GET(cpuid) * CPU_BASE_TRANSITIONS));
+		return (PCPU_GET(idlethread));
+	}
+
+	if (td == NULL ||
 	    (tdcpu != NULL && tdcpu->td_priority < td->td_priority)) {
 		CTR2(KTR_RUNQ, "choosing td %p from pcpu runq %d", tdcpu,
 		    PCPU_GET(cpuid));
@@ -1528,14 +1546,6 @@ sched_choose(void)
 
 		if(td) {
 			resource_fire_net("sched_choose_1", td, TRAN_UNQUEUE + (PCPU_GET(cpuid)*CPU_BASE_TRANSITIONS));
-		}
-		else if (is_cpu_suspended){
-			if(PCPU_GET(idlethread)->td_frominh == 1) {
-				thread_petri_fire(PCPU_GET(idlethread), TRAN_WAKEUP);
-				PCPU_GET(idlethread)->td_frominh = 0;
-			}
-			resource_fire_net("sched_choose_4", PCPU_GET(idlethread), TRAN_EXEC_IDLE + (PCPU_GET(cpuid)*CPU_BASE_TRANSITIONS));
-			return (PCPU_GET(idlethread));
 		}
 	} else{
 		CTR1(KTR_RUNQ, "choosing td_sched %p from main runq", td);

--- a/sys/kern/sched_4bsd.c
+++ b/sys/kern/sched_4bsd.c
@@ -1389,6 +1389,7 @@ sched_add(struct thread *td, int flags)
 	}
 
 	if(cpu != NOCPU) {
+		resource_wakeup_cpu(cpu, td, "sched_add_wakeup_suspended");
 		ts->ts_runq = &runq_pcpu[cpu];
 		resource_fire_net("sched_add", td, TRAN_ADDTOQUEUE+(cpu*CPU_BASE_TRANSITIONS));
 		single_cpu = 1;

--- a/sys/kern/sched_4bsd.c
+++ b/sys/kern/sched_4bsd.c
@@ -701,6 +701,8 @@ int
 sched_runnable(void)
 {
 #ifdef SMP
+	if (resource_cpu_is_suspended(PCPU_GET(cpuid)))
+		return (0);
 	return runq_check(&runq) + runq_check(&runq_pcpu[PCPU_GET(cpuid)]);
 #else
 	return runq_check(&runq);
@@ -1517,7 +1519,7 @@ sched_choose(void)
 	struct runq *rq;
 	int is_cpu_suspended;
 
-	is_cpu_suspended = get_place_tokens_qty(PLACE_SUSPENDED + (PCPU_GET(cpuid)*CPU_BASE_PLACES));
+	is_cpu_suspended = resource_cpu_is_suspended(PCPU_GET(cpuid));
 
 	mtx_assert(&sched_lock,  MA_OWNED);
 #ifdef SMP

--- a/sys/sys/sched_petri.h
+++ b/sys/sys/sched_petri.h
@@ -6,8 +6,8 @@
 
 #define CPU_NUMBER 4
 // FOR GLOBAL TRANISTIONS
-#define CPU_BASE_PLACES 5
-#define CPU_BASE_TRANSITIONS 9
+#define CPU_BASE_PLACES 6
+#define CPU_BASE_TRANSITIONS 12
 #define CPU_NUMBER_PLACES (CPU_BASE_PLACES*CPU_NUMBER)+3
 #define CPU_NUMBER_TRANSITION (CPU_BASE_TRANSITIONS*CPU_NUMBER)+4
 /* Definitions of transition and places for the CPU resource net */
@@ -17,6 +17,7 @@
 #define PLACE_CPU 2
 #define PLACE_TOEXEC 3
 #define PLACE_EXECUTING 4
+#define PLACE_SUSPENDED 5
 
 
 // Global queue independent of the number of CPUs
@@ -29,12 +30,14 @@
 #define TRAN_UNQUEUE 1
 #define TRAN_EXEC 2
 #define TRAN_EXEC_EMPTY 3
-#define TRAN_RETURN_VOL 4
-#define TRAN_RETURN_INVOL 5
-#define TRAN_FROM_GLOBAL_CPU 6
-#define TRAN_REMOVE_QUEUE 7
-#define TRAN_REMOVE_EMPTY_QUEUE 8
-
+#define TRAN_EXEC_IDLE 4
+#define TRAN_RETURN_VOL 5
+#define TRAN_RETURN_INVOL 6
+#define TRAN_FROM_GLOBAL_CPU 7
+#define TRAN_REMOVE_QUEUE 8
+#define TRAN_REMOVE_EMPTY_QUEUE 9
+#define TRAN_SUSPEND_PROC 10
+#define TRAN_WAKEUP_PROC 11
 
 //Global transition
 #define TRAN_REMOVE_GLOBAL_QUEUE (CPU_NUMBER_TRANSITION-4) 
@@ -70,5 +73,7 @@ void resource_execute_thread(struct thread *newtd, int cpu);
 void resource_remove_thread(struct thread *newtd, int cpu);
 void print_detailed_places(void);
 void set_print_transition(int transitions_to_print);
+void toggle_active_cpu(int cpu);
+int get_place_tokens_qty(int place_index);
 
 #endif

--- a/sys/sys/sched_petri.h
+++ b/sys/sys/sched_petri.h
@@ -68,6 +68,7 @@ void resource_get_sensitized(void);
 void resource_fire_net(char *trigger, struct thread *pt, int transition_index);
 int transition_is_sensitized(int transition_index);
 int resource_choose_cpu(struct thread *td);
+int resource_cpu_is_suspended(int cpu);
 void resource_expulse_thread(struct thread *td, int flags);
 void resource_execute_thread(struct thread *newtd, int cpu);
 void resource_remove_thread(struct thread *newtd, int cpu);

--- a/sys/sys/sched_petri.h
+++ b/sys/sys/sched_petri.h
@@ -69,6 +69,7 @@ void resource_fire_net(char *trigger, struct thread *pt, int transition_index);
 int transition_is_sensitized(int transition_index);
 int resource_choose_cpu(struct thread *td);
 int resource_cpu_is_suspended(int cpu);
+void resource_wakeup_cpu(int cpu, struct thread *td, char *trigger);
 void resource_expulse_thread(struct thread *td, int flags);
 void resource_execute_thread(struct thread *newtd, int cpu);
 void resource_remove_thread(struct thread *newtd, int cpu);

--- a/sys/sys/sched_petri.h
+++ b/sys/sys/sched_petri.h
@@ -74,6 +74,7 @@ void resource_remove_thread(struct thread *newtd, int cpu);
 void print_detailed_places(void);
 void set_print_transition(int transitions_to_print);
 void toggle_active_cpu(int cpu);
+void sched_petri_toggle_cpu(int cpu);
 int get_place_tokens_qty(int place_index);
 
 #endif


### PR DESCRIPTION
## Purpose

This PR adds the CPU assignment inhibition module on top of the shared Petri-net scheduler base.

The module lets the prototype mark a CPU as unavailable for normal scheduler work assignment. This is not hardware power management and does not power off a processor. The CPU can still execute the idle thread and must still be allowed to handle unavoidable kernel scheduling paths when FreeBSD requires them.

## What Changed

- Extends the CPU resource Petri-net with a `SUSPENDED` place.
- Adds suspension-related transitions for each CPU:
  - `TRAN_SUSPEND_PROC`
  - `TRAN_WAKEUP_PROC`
  - `TRAN_EXEC_IDLE`
- Updates the Petri-net incidence and inhibition matrices so suspended CPUs stop receiving normal policy-selected work.
- Adds `kern.sched_petri.cpu_toggle` as a manual sysctl control for toggling the scheduler state of a CPU.
- Serializes CPU toggle operations under `sched_lock` so the Petri-net state is not mutated concurrently with normal scheduler activity.
- Updates `sched_choose()` so a suspended CPU follows the idle path instead of continuing normal runqueue selection.
- Updates `sched_add()` so unavoidable per-CPU work can wake a suspended CPU before enqueueing, avoiding Petri-net/kernel state divergence.
- Keeps CPU0 unavailable for this module because it can participate in special kernel paths and platform-specific interrupt or boot-time behavior.

## Relationship to the Base PR

This PR is based on #13 and assumes the shared Petri-net scheduler base is present.

It intentionally includes the testing fixes that were previously in the separate testing PR, so reviewers only need this PR for the full CPU assignment inhibition module.

This PR is not stacked on the CPU monopolization module. The CPU assignment inhibition and CPU monopolization modules are sibling PRs that both target the same Petri-net scheduler base.

## Design Notes

The implementation distinguishes three cases:

- normal policy-selected enqueue decisions, handled by the regular Petri-net enqueue transition;
- suspended CPUs, which should not receive normal work assignment;
- unavoidable per-CPU work, which FreeBSD may still need to enqueue and which is handled through the forced enqueue path provided by the base PR.

This distinction is important because treating every enqueue as an ordinary policy decision can make the Petri-net reject a transition that the kernel must still perform.

## Scope

This PR does not implement hardware CPU hotplug, ACPI C-states, DVFS, or physical CPU power management. It only modifies scheduler-level CPU work assignment in the Petri-net prototype.

## Validation

- `git diff --check` was run while resolving the consolidation merge with the updated base branch.
- The previous CPU assignment inhibition testing PR was merged into this branch before updating it against #13.

Pending before final review:

- rebuild `PI_KERNELCONF`;
- boot the resulting kernel;
- test repeated CPU toggle operations under scheduler stress;
- inspect DTrace output from the base PR to confirm policy vs forced enqueue behavior.
