### PR TITLE
Add Petri-net CPU monopolization module

### DIFF
--- a/sys/kern/petri_global_net.c
+++ b/sys/kern/petri_global_net.c
@@ -25,6 +25,7 @@ int smp_set = 0;
 int print_enabled = 1;
 int transitions_to_print = 0;
 struct petri_cpu_resource_net resource_net;
+static int pinned_threads_per_cpu[CPU_NUMBER] = { -1, -1, -1, -1 };
 
 const int base_resource_matrix[CPU_BASE_PLACES][CPU_BASE_TRANSITIONS] = {
 	/*Base matrix */
@@ -276,11 +277,17 @@ int resource_choose_cpu(struct thread* td)
 	//First we need to know which of the cpu queues is sensitized
 	int transition_index;
 	int best = NOCPU;
+	int tid = (int)td->td_tid;
+
+	best = get_monopolized_cpu_by_thread_id(tid);
+	if (best != NOCPU)
+		return (best);
 
 	if (
 		td->td_lastcpu != NOCPU &&
 		THREAD_CAN_SCHED(td, td->td_lastcpu) &&
-		transition_is_sensitized(td->td_lastcpu * CPU_BASE_TRANSITIONS)
+		transition_is_sensitized(td->td_lastcpu * CPU_BASE_TRANSITIONS) &&
+		cpu_available_for_thread(tid, td->td_lastcpu)
 	) {
 		best = td->td_lastcpu;
 		return best;
@@ -289,10 +296,14 @@ int resource_choose_cpu(struct thread* td)
 	//Only check for transitions of addtoqueue
 	for (transition_index = TRAN_ADDTOQUEUE; transition_index < CPU_NUMBER_TRANSITION-4; transition_index += CPU_BASE_TRANSITIONS) {
 		if (transition_is_sensitized(transition_index)) {
-			if (!THREAD_CAN_SCHED(td, (transition_index / CPU_BASE_TRANSITIONS)))
+			int target_cpu;
+
+			target_cpu = transition_index / CPU_BASE_TRANSITIONS;
+			if (!THREAD_CAN_SCHED(td, target_cpu) ||
+			    !cpu_available_for_thread(tid, target_cpu))
 				continue;
 			else {
-				best = (transition_index / CPU_BASE_TRANSITIONS);
+				best = target_cpu;
 				break;
 			}
 		}
@@ -350,4 +361,39 @@ void print_detailed_places() {
 
 void set_print_transition(int number_transitions) {
 	transitions_to_print = number_transitions;
+}
+
+void
+toggle_pin_thread_to_cpu(int thread_id, int cpu)
+{
+
+	if (cpu <= 0 || cpu >= CPU_NUMBER ||
+	    !cpu_available_for_thread(thread_id, cpu))
+		return;
+
+	if (pinned_threads_per_cpu[cpu] == thread_id)
+		pinned_threads_per_cpu[cpu] = -1;
+	else
+		pinned_threads_per_cpu[cpu] = thread_id;
+}
+
+int
+cpu_available_for_thread(int thread_id, int cpu)
+{
+
+	return (pinned_threads_per_cpu[cpu] == thread_id ||
+	    pinned_threads_per_cpu[cpu] == -1);
+}
+
+int
+get_monopolized_cpu_by_thread_id(int thread_id)
+{
+	int cpu;
+
+	for (cpu = 0; cpu < CPU_NUMBER; cpu++) {
+		if (pinned_threads_per_cpu[cpu] == thread_id)
+			return (cpu);
+	}
+
+	return (NOCPU);
 }

--- a/sys/kern/petri_global_net.c
+++ b/sys/kern/petri_global_net.c
@@ -9,9 +9,13 @@
  */
 
 #include <sys/types.h>
+#include <sys/errno.h>
 #include <sys/param.h>
 #include <sys/cpuset.h>
+#include <sys/kernel.h>
 #include <sys/smp.h>
+#include <sys/sysctl.h>
+#include <sys/systm.h>
 #include <sys/time.h>
 #include <sys/sched_petri.h>
 
@@ -98,6 +102,14 @@ const int hierarchical_corresponse[] = {
 
 static void resource_fire_single_transition(struct thread *pt, int transition_index);
 static int get_automatic_transitions_sensitized(void);
+static int sysctl_sched_petri_monopolize(SYSCTL_HANDLER_ARGS);
+
+SYSCTL_NODE(_kern, OID_AUTO, sched_petri, CTLFLAG_RW | CTLFLAG_MPSAFE, 0,
+    "Petri-net scheduler controls");
+SYSCTL_PROC(_kern_sched_petri, OID_AUTO, monopolize,
+    CTLTYPE_STRING | CTLFLAG_RW | CTLFLAG_MPSAFE, 0, 0,
+    sysctl_sched_petri_monopolize, "A",
+    "Toggle monopolization for a thread/cpu pair using tid:cpu");
 
 void init_resource_net()
 {
@@ -361,6 +373,27 @@ void print_detailed_places() {
 
 void set_print_transition(int number_transitions) {
 	transitions_to_print = number_transitions;
+}
+
+static int
+sysctl_sched_petri_monopolize(SYSCTL_HANDLER_ARGS)
+{
+	char input[32];
+	int cpu;
+	int error;
+	int thread_id;
+
+	input[0] = '\0';
+	error = sysctl_handle_string(oidp, input, sizeof(input), req);
+	if (error != 0 || req->newptr == NULL)
+		return (error);
+	if (sscanf(input, "%d:%d", &thread_id, &cpu) != 2)
+		return (EINVAL);
+	if (thread_id <= 0 || cpu <= 0 || cpu >= CPU_NUMBER)
+		return (EINVAL);
+
+	toggle_pin_thread_to_cpu(thread_id, cpu);
+	return (0);
 }
 
 void

--- a/sys/kern/sched_4bsd.c
+++ b/sys/kern/sched_4bsd.c
@@ -1528,8 +1528,14 @@ sched_choose(void)
 			resource_fire_net("sched_choose", td, TRAN_UNQUEUE + (PCPU_GET(cpuid)*CPU_BASE_TRANSITIONS));
 		}
 	} else{
-		CTR1(KTR_RUNQ, "choosing td_sched %p from main runq", td);
-		resource_fire_net("sched_choose", td, TRAN_FROM_GLOBAL_CPU + (PCPU_GET(cpuid)*CPU_BASE_TRANSITIONS));
+		if (cpu_available_for_thread(td->td_tid, PCPU_GET(cpuid))) {
+			CTR1(KTR_RUNQ, "choosing td_sched %p from main runq", td);
+			resource_fire_net("sched_choose", td,
+			    TRAN_FROM_GLOBAL_CPU +
+			    (PCPU_GET(cpuid) * CPU_BASE_TRANSITIONS));
+		} else {
+			td = NULL;
+		}
 	}
 
 #else

--- a/sys/sys/sched_petri.h
+++ b/sys/sys/sched_petri.h
@@ -70,5 +70,8 @@ void resource_execute_thread(struct thread *newtd, int cpu);
 void resource_remove_thread(struct thread *newtd, int cpu);
 void print_detailed_places(void);
 void set_print_transition(int transitions_to_print);
+void toggle_pin_thread_to_cpu(int thread_id, int cpu);
+int cpu_available_for_thread(int thread_id, int cpu);
+int get_monopolized_cpu_by_thread_id(int thread_id);
 
 #endif


### PR DESCRIPTION
## Purpose

This PR adds the CPU monopolization module on top of the shared Petri-net scheduler base.

The module lets the prototype reserve a CPU for a selected thread. When a thread is associated with a CPU through the module, the scheduler should prefer that CPU for the selected thread and avoid assigning unrelated threads to that CPU through the Petri-net CPU selection path.

## What Changed

- Adds `pinned_threads_per_cpu` to track which thread, if any, has monopolized each CPU.
- Adds helpers to:
  - toggle a thread/CPU monopolization pair;
  - check whether a CPU is available for a given thread;
  - look up the CPU monopolized by a specific thread.
- Adds `kern.sched_petri.monopolize` as a manual sysctl control using the `tid:cpu` format.
- Updates `resource_choose_cpu()` so a monopolized thread is directed to its selected CPU first.
- Updates Petri-net CPU selection so CPUs reserved for another thread are skipped for ordinary scheduling decisions.
- Keeps CPU0 unavailable for monopolization through the sysctl path, matching the conservative CPU0 policy used by the rest of the prototype.

## Relationship to the Base PR

This PR is based on #13 and assumes the shared Petri-net scheduler base is present.

It intentionally includes the testing sysctl work that was previously in the separate testing PR, so reviewers only need this PR for the full CPU monopolization module.

This PR is not stacked on the CPU assignment inhibition module. The CPU monopolization and CPU assignment inhibition modules are sibling PRs that both target the same Petri-net scheduler base.

## Design Notes

This module does not extend the Petri-net with new places or transitions in the same way as the CPU assignment inhibition module. Instead, it adds an external per-CPU ownership constraint that is consulted during CPU selection.

That design keeps the Petri-net resource model focused on scheduler state transitions while using a small ownership table to represent the thread-to-CPU monopolization policy.

The forced enqueue handling in #13 remains important here because FreeBSD may still have mandatory per-CPU scheduling paths for pinned, bound, or affinity-constrained threads.

## Scope

This PR implements manual CPU monopolization for the prototype. It is not a replacement for FreeBSD's native affinity mechanisms such as `cpuset`, `sched_bind`, or existing kernel pinning support. Its value is in showing how the Petri-net scheduler prototype can incorporate an additional scheduling constraint.

## Validation

- `git diff --check` was run while resolving the consolidation merge with the updated base branch.
- The previous CPU monopolization testing PR was merged into this branch before updating it against #13.

Pending before final review:

- rebuild `PI_KERNELCONF`;
- boot the resulting kernel;
- test monopolization with representative runnable-thread workloads;
- compare observed behavior against native FreeBSD affinity/pinning mechanisms where useful.
