### PR TITLE
[stack/cpu-on-off 3/3] Add sysctl trigger for CPU on-off testing

### DIFF
--- a/sys/kern/petri_global_net.c
+++ b/sys/kern/petri_global_net.c
@@ -47,7 +47,7 @@ const int base_resource_inhibition_matrix[CPU_BASE_PLACES][CPU_BASE_TRANSITIONS]
 	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-	{ 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0}
+	{ 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0}
 };
 
 const char *transitions_names[] = {
@@ -343,6 +343,15 @@ resource_cpu_is_suspended(int cpu)
 		return (0);
 	return (resource_net.mark[PLACE_SUSPENDED +
 	    (cpu * CPU_BASE_PLACES)] != 0);
+}
+
+void
+resource_wakeup_cpu(int cpu, struct thread *td, char *trigger)
+{
+	if (!resource_cpu_is_suspended(cpu))
+		return;
+	resource_fire_net(trigger, td, (cpu * CPU_BASE_TRANSITIONS) +
+	    TRAN_WAKEUP_PROC);
 }
 
 void resource_expulse_thread(struct thread *td, int flags) {

--- a/sys/kern/petri_global_net.c
+++ b/sys/kern/petri_global_net.c
@@ -387,7 +387,7 @@ sysctl_sched_petri_cpu_toggle(SYSCTL_HANDLER_ARGS)
 	if (cpu <= 0 || cpu >= CPU_NUMBER)
 		return (EINVAL);
 
-	toggle_active_cpu(cpu);
+	sched_petri_toggle_cpu(cpu);
 	return (0);
 }
 

--- a/sys/kern/petri_global_net.c
+++ b/sys/kern/petri_global_net.c
@@ -47,7 +47,7 @@ const int base_resource_inhibition_matrix[CPU_BASE_PLACES][CPU_BASE_TRANSITIONS]
 	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-	{ 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0}
+	{ 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0}
 };
 
 const char *transitions_names[] = {
@@ -207,6 +207,10 @@ int get_place_tokens_qty(int place_index)
 
 void resource_fire_net(char *trigger, struct thread *pt, int transition_index)
 {
+	if (transition_index < 0 || transition_index >= CPU_NUMBER_TRANSITION)
+		panic("petri-net invalid transition: %d from %s",
+		    transition_index, trigger);
+
 	if(pt) {
 		int automatic_transition;
 
@@ -225,11 +229,15 @@ void resource_fire_net(char *trigger, struct thread *pt, int transition_index)
 		}
 		else {
 			if(print_enabled) {
-				// TODO: Add a kernel panic exit here. We don't care about post error transitions
-				printf("!! %s - Non sensitized transition: %2d - Thread %2d - CPU %2d - FROM %s!!\n", transitions_names[transition_index], transition_index, pt->td_tid, PCPU_GET(cpuid), trigger);
+				printf("!! %s - Non sensitized transition: %2d - Thread %2d - CPU %2d - FROM %s - td_flags %#x - td_pinned %d - td_lastcpu %d!!\n",
+				    transitions_names[transition_index],
+				    transition_index, pt->td_tid, PCPU_GET(cpuid),
+				    trigger, pt->td_flags, pt->td_pinned,
+				    pt->td_lastcpu);
 				print_detailed_places();
-				transitions_to_print = 0;
 			}
+			panic("petri-net non-sensitized transition: %s from %s",
+			    transitions_names[transition_index], trigger);
 		}
 	}
 
@@ -296,12 +304,14 @@ int transition_is_sensitized(int transition_index)
 int resource_choose_cpu(struct thread* td)
 {
 	//First we need to know which of the cpu queues is sensitized
+	int cpu;
 	int transition_index;
 	int best = NOCPU;
 
 	if (
 		td->td_lastcpu != NOCPU &&
 		THREAD_CAN_SCHED(td, td->td_lastcpu) &&
+		!resource_cpu_is_suspended(td->td_lastcpu) &&
 		transition_is_sensitized(td->td_lastcpu * CPU_BASE_TRANSITIONS)
 	) {
 		best = td->td_lastcpu;
@@ -310,17 +320,29 @@ int resource_choose_cpu(struct thread* td)
 
 	//Only check for transitions of addtoqueue
 	for (transition_index = TRAN_ADDTOQUEUE; transition_index < CPU_NUMBER_TRANSITION-4; transition_index += CPU_BASE_TRANSITIONS) {
+		cpu = transition_index / CPU_BASE_TRANSITIONS;
 		if (transition_is_sensitized(transition_index)) {
-			if (!THREAD_CAN_SCHED(td, (transition_index / CPU_BASE_TRANSITIONS)))
+			if (resource_cpu_is_suspended(cpu))
+				continue;
+			if (!THREAD_CAN_SCHED(td, cpu))
 				continue;
 			else {
-				best = (transition_index / CPU_BASE_TRANSITIONS);
+				best = cpu;
 				break;
 			}
 		}
 	}
 
 	return best;
+}
+
+int
+resource_cpu_is_suspended(int cpu)
+{
+	if (cpu < 0 || cpu >= CPU_NUMBER)
+		return (0);
+	return (resource_net.mark[PLACE_SUSPENDED +
+	    (cpu * CPU_BASE_PLACES)] != 0);
 }
 
 void resource_expulse_thread(struct thread *td, int flags) {

--- a/sys/kern/petri_global_net.c
+++ b/sys/kern/petri_global_net.c
@@ -9,9 +9,13 @@
  */
 
 #include <sys/types.h>
+#include <sys/errno.h>
 #include <sys/param.h>
 #include <sys/cpuset.h>
+#include <sys/kernel.h>
 #include <sys/smp.h>
+#include <sys/sysctl.h>
+#include <sys/systm.h>
 #include <sys/time.h>
 #include <sys/sched_petri.h>
 
@@ -103,6 +107,14 @@ const int hierarchical_corresponse[] = {
 
 static void resource_fire_single_transition(struct thread *pt, int transition_index);
 static int get_automatic_transitions_sensitized(void);
+static int sysctl_sched_petri_cpu_toggle(SYSCTL_HANDLER_ARGS);
+
+SYSCTL_NODE(_kern, OID_AUTO, sched_petri, CTLFLAG_RW | CTLFLAG_MPSAFE, 0,
+    "Petri-net scheduler controls");
+SYSCTL_PROC(_kern_sched_petri, OID_AUTO, cpu_toggle,
+    CTLTYPE_INT | CTLFLAG_RW | CTLFLAG_MPSAFE, 0, 0,
+    sysctl_sched_petri_cpu_toggle, "I",
+    "Toggle the Petri-net scheduler state for a CPU by id");
 
 void init_resource_net()
 {
@@ -360,6 +372,23 @@ void print_detailed_places() {
 
 void set_print_transition(int number_transitions) {
 	transitions_to_print = number_transitions;
+}
+
+static int
+sysctl_sched_petri_cpu_toggle(SYSCTL_HANDLER_ARGS)
+{
+	int cpu;
+	int error;
+
+	cpu = -1;
+	error = sysctl_handle_int(oidp, &cpu, 0, req);
+	if (error != 0 || req->newptr == NULL)
+		return (error);
+	if (cpu <= 0 || cpu >= CPU_NUMBER)
+		return (EINVAL);
+
+	toggle_active_cpu(cpu);
+	return (0);
 }
 
 void toggle_active_cpu(int cpu) {

--- a/sys/kern/sched_4bsd.c
+++ b/sys/kern/sched_4bsd.c
@@ -1305,6 +1305,14 @@ sched_petrinet_pickcpu(struct thread *td)
 	cpu = resource_choose_cpu(td);
 	return (cpu);
 }
+
+void
+sched_petri_toggle_cpu(int cpu)
+{
+	mtx_lock_spin(&sched_lock);
+	toggle_active_cpu(cpu);
+	mtx_unlock_spin(&sched_lock);
+}
 #endif
 
 void
@@ -1519,7 +1527,17 @@ sched_choose(void)
 	td = runq_choose_fuzz(&runq, runq_fuzz);
 	tdcpu = runq_choose(&runq_pcpu[PCPU_GET(cpuid)]);
 
-	if (is_cpu_suspended || td == NULL ||
+	if (is_cpu_suspended) {
+		if(PCPU_GET(idlethread)->td_frominh == 1) {
+			thread_petri_fire(PCPU_GET(idlethread), TRAN_WAKEUP);
+			PCPU_GET(idlethread)->td_frominh = 0;
+		}
+		resource_fire_net("sched_choose_4", PCPU_GET(idlethread),
+		    TRAN_EXEC_IDLE + (PCPU_GET(cpuid) * CPU_BASE_TRANSITIONS));
+		return (PCPU_GET(idlethread));
+	}
+
+	if (td == NULL ||
 	    (tdcpu != NULL && tdcpu->td_priority < td->td_priority)) {
 		CTR2(KTR_RUNQ, "choosing td %p from pcpu runq %d", tdcpu,
 		    PCPU_GET(cpuid));
@@ -1528,14 +1546,6 @@ sched_choose(void)
 
 		if(td) {
 			resource_fire_net("sched_choose_1", td, TRAN_UNQUEUE + (PCPU_GET(cpuid)*CPU_BASE_TRANSITIONS));
-		}
-		else if (is_cpu_suspended){
-			if(PCPU_GET(idlethread)->td_frominh == 1) {
-				thread_petri_fire(PCPU_GET(idlethread), TRAN_WAKEUP);
-				PCPU_GET(idlethread)->td_frominh = 0;
-			}
-			resource_fire_net("sched_choose_4", PCPU_GET(idlethread), TRAN_EXEC_IDLE + (PCPU_GET(cpuid)*CPU_BASE_TRANSITIONS));
-			return (PCPU_GET(idlethread));
 		}
 	} else{
 		CTR1(KTR_RUNQ, "choosing td_sched %p from main runq", td);

--- a/sys/kern/sched_4bsd.c
+++ b/sys/kern/sched_4bsd.c
@@ -1389,6 +1389,7 @@ sched_add(struct thread *td, int flags)
 	}
 
 	if(cpu != NOCPU) {
+		resource_wakeup_cpu(cpu, td, "sched_add_wakeup_suspended");
 		ts->ts_runq = &runq_pcpu[cpu];
 		resource_fire_net("sched_add", td, TRAN_ADDTOQUEUE+(cpu*CPU_BASE_TRANSITIONS));
 		single_cpu = 1;

--- a/sys/kern/sched_4bsd.c
+++ b/sys/kern/sched_4bsd.c
@@ -701,6 +701,8 @@ int
 sched_runnable(void)
 {
 #ifdef SMP
+	if (resource_cpu_is_suspended(PCPU_GET(cpuid)))
+		return (0);
 	return runq_check(&runq) + runq_check(&runq_pcpu[PCPU_GET(cpuid)]);
 #else
 	return runq_check(&runq);
@@ -1517,7 +1519,7 @@ sched_choose(void)
 	struct runq *rq;
 	int is_cpu_suspended;
 
-	is_cpu_suspended = get_place_tokens_qty(PLACE_SUSPENDED + (PCPU_GET(cpuid)*CPU_BASE_PLACES));
+	is_cpu_suspended = resource_cpu_is_suspended(PCPU_GET(cpuid));
 
 	mtx_assert(&sched_lock,  MA_OWNED);
 #ifdef SMP

--- a/sys/sys/sched_petri.h
+++ b/sys/sys/sched_petri.h
@@ -68,6 +68,7 @@ void resource_get_sensitized(void);
 void resource_fire_net(char *trigger, struct thread *pt, int transition_index);
 int transition_is_sensitized(int transition_index);
 int resource_choose_cpu(struct thread *td);
+int resource_cpu_is_suspended(int cpu);
 void resource_expulse_thread(struct thread *td, int flags);
 void resource_execute_thread(struct thread *newtd, int cpu);
 void resource_remove_thread(struct thread *newtd, int cpu);

--- a/sys/sys/sched_petri.h
+++ b/sys/sys/sched_petri.h
@@ -69,6 +69,7 @@ void resource_fire_net(char *trigger, struct thread *pt, int transition_index);
 int transition_is_sensitized(int transition_index);
 int resource_choose_cpu(struct thread *td);
 int resource_cpu_is_suspended(int cpu);
+void resource_wakeup_cpu(int cpu, struct thread *td, char *trigger);
 void resource_expulse_thread(struct thread *td, int flags);
 void resource_execute_thread(struct thread *newtd, int cpu);
 void resource_remove_thread(struct thread *newtd, int cpu);

--- a/sys/sys/sched_petri.h
+++ b/sys/sys/sched_petri.h
@@ -74,6 +74,7 @@ void resource_remove_thread(struct thread *newtd, int cpu);
 void print_detailed_places(void);
 void set_print_transition(int transitions_to_print);
 void toggle_active_cpu(int cpu);
+void sched_petri_toggle_cpu(int cpu);
 int get_place_tokens_qty(int place_index);
 
 #endif


### PR DESCRIPTION
Stack context:
- Base stack PR: feature/petri-net-scheduler -> release13.1
- Module stack PR: feature/petri-net-scheduler_cpu-on-off-module -> feature/petri-net-scheduler
- This PR: testing/petri-net-scheduler_cpu-on-off-module -> feature/petri-net-scheduler_cpu-on-off-module

This PR adds only the testing activation path for the CPU on-off module via `kern.sched_petri.cpu_toggle`, leaving the clean module branch unchanged.