### PR TITLE
feat(petri-net): add forced per-cpu enqueue transition

### DIFF
--- a/sys/kern/petri_global_net.c
+++ b/sys/kern/petri_global_net.c
@@ -28,27 +28,27 @@ struct petri_cpu_resource_net resource_net;
 
 const int base_resource_matrix[CPU_BASE_PLACES][CPU_BASE_TRANSITIONS] = {
 	/*Base matrix */
-	{ 1, 0,-1, 0, 0, 0, 0,-1, 0},
-	{ 1,-1, 0, 0, 0, 0, 0,-1,-1},
-	{ 0,-1, 0, 0, 1, 1,-1, 0, 0},
-	{ 0, 1,-1,-1, 0, 0, 1, 0, 0},
-	{ 0, 0, 1, 1,-1,-1, 0, 0, 0}
+	{ 1, 0,-1, 0, 0, 0, 0,-1, 0, 1},
+	{ 1,-1, 0, 0, 0, 0, 0,-1,-1, 1},
+	{ 0,-1, 0, 0, 1, 1,-1, 0, 0, 0},
+	{ 0, 1,-1,-1, 0, 0, 1, 0, 0, 0},
+	{ 0, 0, 1, 1,-1,-1, 0, 0, 0, 0}
 };
 
 const int base_resource_inhibition_matrix[CPU_BASE_PLACES][CPU_BASE_TRANSITIONS] = {
 	/*Base inhibition matrix */
-	{ 0, 0, 0, 1, 0, 0, 0, 0, 1},
-	{ 0, 0, 0, 0, 0, 0, 0, 0, 0},
-	{ 0, 0, 0, 0, 0, 0, 0, 0, 0},
-	{ 0, 0, 0, 0, 0, 0, 0, 0, 0},
-	{ 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	{ 1, 0, 0, 1, 0, 0, 0, 0, 1, 0},
+	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 };
 
 const char *transitions_names[] = {
-	"ADDTOQUEUE_P0", "UNQUEUE_P0", "EXEC_P0", "EXEC_EMPTY_P0", "RETURN_VOL_P0", "RETURN_INVOL_P0", "FROM_GLOBAL_CPU_P0", "REMOVE_QUEUE_P0", "REMOVE_EMPTY_QUEUE_P0",
-	"ADDTOQUEUE_P1", "UNQUEUE_P1", "EXEC_P1", "EXEC_EMPTY_P1", "RETURN_VOL_P1", "RETURN_INVOL_P1", "FROM_GLOBAL_CPU_P1", "REMOVE_QUEUE_P1", "REMOVE_EMPTY_QUEUE_P1",
-	"ADDTOQUEUE_P2", "UNQUEUE_P2", "EXEC_P2", "EXEC_EMPTY_P2", "RETURN_VOL_P2", "RETURN_INVOL_P2", "FROM_GLOBAL_CPU_P2", "REMOVE_QUEUE_P2", "REMOVE_EMPTY_QUEUE_P2",
-	"ADDTOQUEUE_P3", "UNQUEUE_P3", "EXEC_P3", "EXEC_EMPTY_P3", "RETURN_VOL_P3", "RETURN_INVOL_P3", "FROM_GLOBAL_CPU_P3", "REMOVE_QUEUE_P3", "REMOVE_EMPTY_QUEUE_P3",
+	"ADDTOQUEUE_P0", "UNQUEUE_P0", "EXEC_P0", "EXEC_EMPTY_P0", "RETURN_VOL_P0", "RETURN_INVOL_P0", "FROM_GLOBAL_CPU_P0", "REMOVE_QUEUE_P0", "REMOVE_EMPTY_QUEUE_P0", "ADDTOQUEUE_FORCED_P0",
+	"ADDTOQUEUE_P1", "UNQUEUE_P1", "EXEC_P1", "EXEC_EMPTY_P1", "RETURN_VOL_P1", "RETURN_INVOL_P1", "FROM_GLOBAL_CPU_P1", "REMOVE_QUEUE_P1", "REMOVE_EMPTY_QUEUE_P1", "ADDTOQUEUE_FORCED_P1",
+	"ADDTOQUEUE_P2", "UNQUEUE_P2", "EXEC_P2", "EXEC_EMPTY_P2", "RETURN_VOL_P2", "RETURN_INVOL_P2", "FROM_GLOBAL_CPU_P2", "REMOVE_QUEUE_P2", "REMOVE_EMPTY_QUEUE_P2", "ADDTOQUEUE_FORCED_P2",
+	"ADDTOQUEUE_P3", "UNQUEUE_P3", "EXEC_P3", "EXEC_EMPTY_P3", "RETURN_VOL_P3", "RETURN_INVOL_P3", "FROM_GLOBAL_CPU_P3", "REMOVE_QUEUE_P3", "REMOVE_EMPTY_QUEUE_P3", "ADDTOQUEUE_FORCED_P3",
 	"REMOVE_GLOBAL_QUEUE", "START_SMP", "THROW", "QUEUE_GLOBAL"
 };
 
@@ -62,6 +62,7 @@ const int hierarchical_transitions[] = {
 	TRAN_RETURN_VOL,
 	TRAN_REMOVE_QUEUE,
 	TRAN_REMOVE_EMPTY_QUEUE,
+	TRAN_ADDTOQUEUE_FORCED,
 	TRAN_QUEUE_GLOBAL,
 	TRAN_REMOVE_GLOBAL_QUEUE
 };
@@ -75,25 +76,14 @@ const int hierarchical_corresponse[] = {
 	TRAN_REMOVE,
 	TRAN_REMOVE,
 	TRAN_ON_QUEUE,
+	TRAN_ON_QUEUE,
 	TRAN_REMOVE
 };
 
-/* Extended matrix izq der                GLOBAL TRANSITIONS
-	{ 1, 0,-1, 0, 0, 0, 0,-1, 0},					  	       ,{ 0, 0, 0,-1, 0}
-	{ 1,-1, 0, 0, 0, 0, 0,-1,-1},					           ,{ 0, 0, 0, 0, 0}
-	{ 0,-1, 0, 0, 1, 1,-1, 0, 0},					           ,{ 0, 0, 0, 0, 0}
-	{ 0, 1,-1,-1, 0, 0, 1, 0, 0}					           ,{ 0,-1, 0, 0, 0}
-	{ 0, 0, 1, 1,-1,-1, 0, 0, 0}					           ,{ 0, 0, 0, 0, 0}
-						         { 1, 0,-1, 0, 0, 0, 0,-1, 0}, ,{ 0, 0, 0,-1, 0}
-							     { 1,-1, 0, 0, 0, 0, 0,-1,-1}, ,{ 0, 0, 0, 0, 0}
-							     { 0,-1, 0, 0, 1, 1,-1, 0, 0}, ,{ 0, 0, 0, 0, 0}
-							     { 0, 1,-1,-1, 0, 0, 1, 0, 0}  ,{ 0, 0, 0, 0, 0}
-							     { 0, 0, 1, 1,-1,-1, 0, 0, 0}  ,{ 0, 0, 0, 0, 0}
-	GLOBAL PLACE
-	{ 0, 0, 0, 0, 0, 0,-1, 0, 0} { 0, 0, 0, 0, 0, 0,-1, 0, 0}  ,{-1, 0, 0, 0, 1}
-	{ 0, 0, 0, 0, 0, 0, 0, 0, 0} { 0, 0, 0, 0, 0, 0, 0, 0, 0}  ,{ 0, 0,-1, 0, 0}
-	{ 0, 0, 0, 0, 0, 0, 0, 0, 0} { 0, 0, 0, 0, 0, 0, 0, 0, 0}  ,{ 0, 0, 1, 0, 0}
-*/
+/*
+ * ADDTOQUEUE is the policy enqueue and is inhibited by CANTQ.
+ * ADDTOQUEUE_FORCED has the same incidence, but CANTQ does not inhibit it.
+ */
 
 static void resource_fire_single_transition(struct thread *pt, int transition_index);
 static int get_automatic_transitions_sensitized(void);
@@ -131,6 +121,7 @@ void init_resource_net()
 		//INHIBIT exec if smp not started
 		resource_net.inhibition_matrix[PLACE_SMP_NOT_READY][(num_cpu*CPU_BASE_TRANSITIONS) + TRAN_EXEC] = 1;
 		resource_net.inhibition_matrix[PLACE_SMP_NOT_READY][(num_cpu*CPU_BASE_TRANSITIONS) + TRAN_ADDTOQUEUE] = 1;
+		resource_net.inhibition_matrix[PLACE_SMP_NOT_READY][(num_cpu*CPU_BASE_TRANSITIONS) + TRAN_ADDTOQUEUE_FORCED] = 1;
 	}
 
 	//Transition to remove from global queue

--- a/sys/kern/petri_global_net.c
+++ b/sys/kern/petri_global_net.c
@@ -80,11 +80,6 @@ const int hierarchical_corresponse[] = {
 	TRAN_REMOVE
 };
 
-/*
- * ADDTOQUEUE is the policy enqueue and is inhibited by CANTQ.
- * ADDTOQUEUE_FORCED has the same incidence, but CANTQ does not inhibit it.
- */
-
 static void resource_fire_single_transition(struct thread *pt, int transition_index);
 static int get_automatic_transitions_sensitized(void);
 

--- a/sys/kern/sched_4bsd.c
+++ b/sys/kern/sched_4bsd.c
@@ -1319,6 +1319,8 @@ sched_add(struct thread *td, int flags)
 	cpuset_t tidlemsk;
 	struct td_sched *ts;
 	u_int cpu = NOCPU, cpuid;
+	int add_transition;
+	int forced_addtoqueue = 0;
 	int forwarded = 0;
 	int single_cpu = 0;
 
@@ -1362,25 +1364,31 @@ sched_add(struct thread *td, int flags)
     */
 	if (smp_started && (td->td_pinned != 0 || td->td_flags & TDF_BOUND ||
 	    ts->ts_flags & TSF_AFFINITY)) {
-		if (td->td_pinned != 0 && td->td_lastcpu != NOCPU &&
-		    transition_is_sensitized(td->td_lastcpu *
-			CPU_BASE_TRANSITIONS))
-			cpu = td->td_lastcpu;
-		else if (td->td_flags & TDF_BOUND) {
+		if (td->td_pinned != 0) {
+			if (td->td_lastcpu != NOCPU)
+				cpu = td->td_lastcpu;
+			else
+				cpu = sched_pickcpu(td);
+			forced_addtoqueue = 1;
+		} else if (td->td_flags & TDF_BOUND) {
 			KASSERT(SKE_RUNQ_PCPU(ts),
 			    ("sched_add: bound td_sched not on cpu runq"));
 			cpu = ts->ts_runq - &runq_pcpu[0];
+			forced_addtoqueue = 1;
 		} else {
 			/* Find a valid CPU for our cpuset. */
 			cpu = sched_petrinet_pickcpu(td);
-			if (cpu == NOCPU)
+			if (cpu == NOCPU) {
 				cpu = sched_pickcpu(td);
+				forced_addtoqueue = 1;
+			}
 		}
 	}
 
 	if(cpu != NOCPU) {
 		ts->ts_runq = &runq_pcpu[cpu];
-		resource_fire_net("sched_add", td, TRAN_ADDTOQUEUE+(cpu*CPU_BASE_TRANSITIONS));
+		add_transition = forced_addtoqueue ? TRAN_ADDTOQUEUE_FORCED : TRAN_ADDTOQUEUE;
+		resource_fire_net("sched_add", td, add_transition+(cpu*CPU_BASE_TRANSITIONS));
 		single_cpu = 1;
 		CTR3(KTR_RUNQ,
 			"sched_add: Put td_sched:%p(td:%p) on cpu%d runq", ts, td,

--- a/sys/sys/sched_petri.h
+++ b/sys/sys/sched_petri.h
@@ -7,7 +7,7 @@
 #define CPU_NUMBER 4
 // FOR GLOBAL TRANISTIONS
 #define CPU_BASE_PLACES 5
-#define CPU_BASE_TRANSITIONS 9
+#define CPU_BASE_TRANSITIONS 10
 #define CPU_NUMBER_PLACES (CPU_BASE_PLACES*CPU_NUMBER)+3
 #define CPU_NUMBER_TRANSITION (CPU_BASE_TRANSITIONS*CPU_NUMBER)+4
 /* Definitions of transition and places for the CPU resource net */
@@ -34,6 +34,7 @@
 #define TRAN_FROM_GLOBAL_CPU 6
 #define TRAN_REMOVE_QUEUE 7
 #define TRAN_REMOVE_EMPTY_QUEUE 8
+#define TRAN_ADDTOQUEUE_FORCED 9
 
 
 //Global transition


### PR DESCRIPTION
Add ADDTOQUEUE_FORCED as a separate per-CPU enqueue transition.

ADDTOQUEUE is restored as the policy transition and is again inhibited by CANTQ. ADDTOQUEUE_FORCED has the same incidence over QUEUE and CANTQ, but is not inhibited by CANTQ, so the Petri net can still record enqueue events that FreeBSD must perform for pinned, bound, or affinity fallback threads.

This preserves CANTQ as a balancing signal for free CPU-selection cases while avoiding scheduler/Petri desynchronization for forced per-CPU placements.