### PR TITLE
Port Petri-net scheduler prototype to main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ tags
 .ccls-cache
 sys/*/compile
 /src.conf
+/thesis-wiki/
+/tesis-wiki/

--- a/sys/amd64/conf/PI_KERNELCONF
+++ b/sys/amd64/conf/PI_KERNELCONF
@@ -1,0 +1,408 @@
+#
+# GENERIC -- Generic kernel configuration file for FreeBSD/amd64
+#
+# For more information on this file, please read the config(5) manual page,
+# and/or the handbook section on Kernel Configuration Files:
+#
+#    https://docs.freebsd.org/en/books/handbook/kernelconfig/#kernelconfig-config
+#
+# The handbook is also available locally in /usr/share/doc/handbook
+# if you've installed the doc distribution, otherwise always see the
+# FreeBSD World Wide Web server (https://www.FreeBSD.org/) for the
+# latest information.
+#
+# An exhaustive list of options and more detailed explanations of the
+# device lines is also present in the ../../conf/NOTES and NOTES files.
+# If you are in doubt as to the purpose or necessity of a line, check first
+# in NOTES.
+#
+
+cpu		HAMMER
+ident		PI_KERNELCONF
+
+makeoptions	DEBUG=-g		# Build kernel with gdb(1) debug symbols
+makeoptions	WITH_CTF=1		# Run ctfconvert(1) for DTrace support
+
+# options 	SCHED_ULE		# ULE scheduler
+options 	SCHED_4BSD		# 4BSD scheduler
+options 	NUMA			# Non-Uniform Memory Architecture support
+options 	PREEMPTION		# Enable kernel thread preemption
+options 	EXTERR_STRINGS
+options 	VIMAGE			# Subsystem virtualization, e.g. VNET
+options 	INET			# InterNETworking
+options 	INET6			# IPv6 communications protocols
+options 	IPSEC_SUPPORT		# Allow kldload of ipsec and tcpmd5
+options 	IPSEC_OFFLOAD		# Inline ipsec offload infra
+options 	FIB_ALGO		# Modular fib lookups
+options 	TCP_OFFLOAD		# TCP offload
+options 	TCP_BLACKBOX		# Enhanced TCP event logging
+options 	TCP_HHOOK		# hhook(9) framework for TCP
+options 	TCP_RFC7413		# TCP Fast Open
+options 	SCTP_SUPPORT		# Allow kldload of SCTP
+options 	KERN_TLS		# TLS transmit & receive offload
+options 	FFS			# Berkeley Fast Filesystem
+options 	SOFTUPDATES		# Enable FFS soft updates support
+options 	UFS_ACL			# Support for access control lists
+options 	UFS_DIRHASH		# Improve performance on big directories
+options 	UFS_GJOURNAL		# Enable gjournal-based UFS journaling
+options 	QUOTA			# Enable disk quotas for UFS
+options 	MD_ROOT			# MD is a potential root device
+options 	NFSCL			# Network Filesystem Client
+options 	NFSD			# Network Filesystem Server
+options 	NFSLOCKD		# Network Lock Manager
+options 	NFS_ROOT		# NFS usable as /, requires NFSCL
+options 	MSDOSFS			# MSDOS Filesystem
+options 	CD9660			# ISO 9660 Filesystem
+options 	PROCFS			# Process filesystem (requires PSEUDOFS)
+options 	PSEUDOFS		# Pseudo-filesystem framework
+options 	TMPFS			# Efficient memory filesystem
+options 	GEOM_RAID		# Soft RAID functionality.
+options 	GEOM_LABEL		# Provides labelization
+options 	EFIRT			# EFI Runtime Services support
+options 	COMPAT_FREEBSD32	# Compatible with i386 binaries
+options 	COMPAT_FREEBSD4		# Compatible with FreeBSD4
+options 	COMPAT_FREEBSD5		# Compatible with FreeBSD5
+options 	COMPAT_FREEBSD6		# Compatible with FreeBSD6
+options 	COMPAT_FREEBSD7		# Compatible with FreeBSD7
+options 	COMPAT_FREEBSD9		# Compatible with FreeBSD9
+options 	COMPAT_FREEBSD10	# Compatible with FreeBSD10
+options 	COMPAT_FREEBSD11	# Compatible with FreeBSD11
+options 	COMPAT_FREEBSD12	# Compatible with FreeBSD12
+options 	COMPAT_FREEBSD13	# Compatible with FreeBSD13
+options 	COMPAT_FREEBSD14	# Compatible with FreeBSD14
+options 	SCSI_DELAY=5000		# Delay (in ms) before probing SCSI
+options 	KTRACE			# ktrace(1) support
+options 	STACK			# stack(9) support
+options 	SYSVSHM			# SYSV-style shared memory
+options 	SYSVMSG			# SYSV-style message queues
+options 	SYSVSEM			# SYSV-style semaphores
+options 	_KPOSIX_PRIORITY_SCHEDULING # POSIX P1003_1B real-time extensions
+options 	PRINTF_BUFR_SIZE=128	# Prevent printf output being interspersed.
+options 	KBD_INSTALL_CDEV	# install a CDEV entry in /dev
+options 	HWPMC_HOOKS		# Necessary kernel hooks for hwpmc(4)
+options 	AUDIT			# Security event auditing
+options 	CAPABILITY_MODE		# Capsicum capability mode
+options 	CAPABILITIES		# Capsicum capabilities
+options 	MAC			# TrustedBSD MAC Framework
+options 	KDTRACE_FRAME		# Ensure frames are compiled in
+options 	KDTRACE_HOOKS		# Kernel DTrace hooks
+options 	DDB_CTF			# Kernel ELF linker loads CTF data
+options 	INCLUDE_CONFIG_FILE	# Include this file in kernel
+options 	RACCT			# Resource accounting framework
+options 	RACCT_DEFAULT_TO_DISABLED # Set kern.racct.enable=0 by default
+options 	RCTL			# Resource limits
+
+# Debugging support.  Always need this:
+options 	KDB			# Enable kernel debugger support.
+options 	KDB_TRACE		# Print a stack trace for a panic.
+# For full debugger support use (turn off in stable branch):
+include "std.debug"
+# PI_KERNELCONF is the development kernel used for the Petri-net scheduler
+# prototype. Keep extra checks enabled here without changing GENERIC.
+options 	DIAGNOSTIC		# Extra kernel consistency checks
+options 	KDB_UNATTENDED		# Do not stop at debugger prompt on panic
+
+# Compression support
+options 	GZIO			# gzip (dumps)
+options 	ZSTDIO			# zstd (dumps, tarfs, uzip, zfs)
+
+# Kernel dump features.
+options 	EKCD			# Support for encrypted kernel dumps
+options 	DEBUGNET		# debugnet networking
+options 	NETDUMP			# netdump(4) client support
+options 	NETGDB			# netgdb(4) client support
+
+# Make an SMP-capable kernel by default
+options 	SMP			# Symmetric MultiProcessor Kernel
+
+# CPU frequency control
+device		cpufreq
+
+# Bus support.
+device		acpi
+device		smbios
+options 	IOMMU
+device		pci
+options 	PCI_HP			# PCI-Express native HotPlug
+options 	PCI_IOV			# PCI SR-IOV support
+
+options 	COMPAT_LINUXKPI
+
+# Enable support for the kernel PLL to use an external PPS signal,
+# under supervision of [x]ntpd(8)
+# More info in ntpd documentation: http://www.eecis.udel.edu/~ntp
+
+options 	PPS_SYNC
+
+# Floppy drives
+device		fdc
+
+# ATA controllers
+device		ahci			# AHCI-compatible SATA controllers
+device		ata			# Legacy ATA/SATA controllers
+device		mvs			# Marvell 88SX50XX/88SX60XX/88SX70XX/SoC SATA
+device		siis			# SiliconImage SiI3124/SiI3132/SiI3531 SATA
+
+# SCSI Controllers
+device		ahc			# AHA2940 and onboard AIC7xxx devices
+device		ahd			# AHA39320/29320 and onboard AIC79xx devices
+device		hptiop			# Highpoint RocketRaid 3xxx series
+device		isp			# Qlogic family
+#device		ispfw			# Firmware for QLogic HBAs- normally a module
+device		mpt			# LSI-Logic MPT-Fusion
+device		mps			# LSI-Logic MPT-Fusion 2
+device		mpr			# LSI-Logic MPT-Fusion 3
+device		mpi3mr			# LSI-Logic MPT-Fusion 4
+device		sym			# NCR/Symbios Logic
+device		isci			# Intel C600 SAS controller
+device		ocs_fc			# Emulex FC adapters
+device		pvscsi			# VMware PVSCSI
+
+# ATA/SCSI peripherals
+device		scbus			# SCSI bus (required for ATA/SCSI)
+device		ch			# SCSI media changers
+device		da			# Direct Access (disks)
+device		sa			# Sequential Access (tape etc)
+device		cd			# CD
+device		pass			# Passthrough device (direct ATA/SCSI access)
+device		ses			# Enclosure Services (SES and SAF-TE)
+#device		ctl			# CAM Target Layer
+
+# RAID controllers interfaced to the SCSI subsystem
+device		arcmsr			# Areca SATA II RAID
+device		ciss			# Compaq Smart RAID 5*
+device		ips			# IBM (Adaptec) ServeRAID
+device		smartpqi		# Microsemi smartpqi driver
+device		tws			# LSI 3ware 9750 SATA+SAS 6Gb/s RAID controller
+
+# RAID controllers
+device		aac			# Adaptec FSA RAID
+device		aacp			# SCSI passthrough for aac (requires CAM)
+device		aacraid			# Adaptec by PMC RAID
+device		ida			# Compaq Smart RAID
+device		mfi			# LSI MegaRAID SAS
+device		mlx			# Mylex DAC960 family
+device		mrsas			# LSI/Avago MegaRAID SAS/SATA, 6Gb/s and 12Gb/s
+#XXX pointer/int warnings
+#device		pst			# Promise Supertrak SX6000
+
+# NVM Express (NVMe) support
+device		nvme			# base NVMe driver
+device		nvd			# expose NVMe namespaces as disks, depends on nvme
+
+# Universal Flash Storage Host Controller Interface support
+device 		ufshci			# UFS host controller
+
+# Intel Volume Management Device (VMD) support
+device		vmd
+
+# atkbdc0 controls both the keyboard and the PS/2 mouse
+device		atkbdc			# AT keyboard controller
+device		atkbd			# AT keyboard
+device		psm			# PS/2 mouse
+
+device		kbdmux			# keyboard multiplexer
+
+# syscons is the legacy console driver, resembling an SCO console
+device		vga			# VGA video card driver
+device		splash			# Splash screen and screen saver support
+device		sc
+options 	SC_PIXEL_MODE		# add support for the raster text mode
+
+# vt is the default video console driver
+device		vt
+device		vt_vga
+device		vt_efifb
+device		vt_vbefb
+
+device		agp			# support several AGP chipsets
+
+# CardBus bridge support
+device		cbb			# CardBus (yenta) bridge
+device		cardbus			# CardBus (32-bit) bus
+
+# Serial (COM) ports
+device		uart			# Generic UART driver
+
+# Parallel port
+device		ppc
+device		ppbus			# Parallel port bus (required)
+device		lpt			# Printer
+device		ppi			# Parallel port interface device
+#device		vpo			# Requires scbus and da
+
+device		puc			# Multi I/O cards and multi-channel UARTs
+
+# MDIO bus for Ethernet NICs that directly expose the MDIO bus
+device		mdio
+
+# PCI/PCI-X/PCIe Ethernet NICs that use iflib infrastructure
+device		iflib
+device		em			# Intel PRO/1000 Gigabit Ethernet Family
+device		igc			# Intel I225 2.5G Ethernet
+device		ix			# Intel PRO/10GbE PCIE PF Ethernet
+device		ixv			# Intel PRO/10GbE PCIE VF Ethernet
+device		ixl			# Intel 700 Series Physical Function
+device		iavf			# Intel Adaptive Virtual Function
+device		ice			# Intel 800 Series Physical Function
+device		vmx			# VMware VMXNET3 Ethernet
+device		axp			# AMD EPYC integrated NIC (requires miibus)
+
+# PCI Ethernet NICs.
+device		aq			# Aquantia / Marvell AQC1xx
+device		bxe			# Broadcom NetXtreme II BCM5771X/BCM578XX 10GbE
+device		rge			# Realtek 8125/8126/8127
+device		ti			# Alteon Networks Tigon I/II gigabit Ethernet
+
+# Nvidia/Mellanox Connect-X 4 and later, Ethernet only
+#  o requires COMPAT_LINUXKPI and xz(4)
+#  o mlx5ib requires ibcore infra and is not included by default
+device		mlx5			# Base driver
+device		mlxfw			# Firmware update
+device		mlx5en			# Ethernet driver
+
+# PCI Ethernet NICs that use the common MII bus controller code.
+# NOTE: Be sure to keep the 'device miibus' line in order to use these NICs!
+device		miibus			# MII bus support
+device		ae			# Attansic/Atheros L2 FastEthernet
+device		age			# Attansic/Atheros L1 Gigabit Ethernet
+device		alc			# Atheros AR8131/AR8132 Ethernet
+device		ale			# Atheros AR8121/AR8113/AR8114 Ethernet
+device		bce			# Broadcom BCM5706/BCM5708 Gigabit Ethernet
+device		bfe			# Broadcom BCM440x 10/100 Ethernet
+device		bge			# Broadcom BCM570xx Gigabit Ethernet
+device		cas			# Sun Cassini/Cassini+ and NS DP83065 Saturn
+device		dc			# DEC/Intel 21143 and various workalikes
+device		et			# Agere ET1310 10/100/Gigabit Ethernet
+device		fxp			# Intel EtherExpress PRO/100B (82557, 82558)
+device		gem			# Sun GEM/Sun ERI/Apple GMAC
+device		jme			# JMicron JMC250 Gigabit/JMC260 Fast Ethernet
+device		lge			# Level 1 LXT1001 gigabit Ethernet
+device		msk			# Marvell/SysKonnect Yukon II Gigabit Ethernet
+device		nfe			# nVidia nForce MCP on-board Ethernet
+device		nge			# NatSemi DP83820 gigabit Ethernet
+device		re			# Realtek 8139C+/8169/8169S/8110S
+device		rl			# Realtek 8129/8139
+device		sge			# Silicon Integrated Systems SiS190/191
+device		sis			# Silicon Integrated Systems SiS 900/SiS 7016
+device		sk			# SysKonnect SK-984x & SK-982x gigabit Ethernet
+device		ste			# Sundance ST201 (D-Link DFE-550TX)
+device		stge			# Sundance/Tamarack TC9021 gigabit Ethernet
+device		vge			# VIA VT612x gigabit Ethernet
+device		vr			# VIA Rhine, Rhine II
+device		xl			# 3Com 3c90x (``Boomerang'', ``Cyclone'')
+
+# Wireless NIC cards
+device		wlan			# 802.11 support
+options 	IEEE80211_DEBUG		# enable debug msgs
+options 	IEEE80211_SUPPORT_MESH	# enable 802.11s draft support
+device		wlan_wep		# 802.11 WEP support
+device		wlan_tkip		# 802.11 TKIP support
+device		wlan_ccmp		# 802.11 CCMP support
+device		wlan_gcmp		# 802.11 GCMP support
+device		wlan_amrr		# AMRR transmit rate control algorithm
+device		ath			# Atheros CardBus/PCI NICs
+device		ath_hal			# Atheros CardBus/PCI chip support
+options 	AH_AR5416_INTERRUPT_MITIGATION # AR5416 interrupt mitigation
+device		ath_rate_sample		# SampleRate tx rate control for ath
+#device		bwi			# Broadcom BCM430x/BCM431x wireless NICs.
+#device		bwn			# Broadcom BCM43xx wireless NICs.
+device		ipw			# Intel 2100 wireless NICs.
+device		iwi			# Intel 2200BG/2225BG/2915ABG wireless NICs.
+device		iwn			# Intel 4965/1000/5000/6000 wireless NICs.
+device		malo			# Marvell Libertas wireless NICs.
+device		mwl			# Marvell 88W8363 802.11n wireless NICs.
+device		ral			# Ralink Technology RT2500 wireless NICs.
+device		wpi			# Intel 3945ABG wireless NICs.
+
+# Pseudo devices.
+device		crypto			# core crypto support
+device		aesni			# AES-NI OpenCrypto module
+device		loop			# Network loopback
+device		ether			# Ethernet support
+device		vlan			# 802.1Q VLAN support
+device		tuntap			# Packet tunnel.
+device		md			# Memory "disks"
+device		gif			# IPv6 and IPv4 tunneling
+device		firmware		# firmware assist module
+device		xz			# lzma decompression
+
+# The `bpf' device enables the Berkeley Packet Filter.
+# Be aware of the administrative consequences of enabling this!
+# Note that 'bpf' is required for DHCP.
+device		bpf			# Berkeley packet filter
+
+# random(4)
+device		rdrand_rng		# Intel Bull Mountain RNG
+# Disabled for now since tpm(4) breaks suspend/resume.
+#device		tpm			# Trusted Platform Module
+options 	RANDOM_ENABLE_TPM	# enable entropy from TPM 2.0
+options 	RANDOM_ENABLE_KBD
+options 	RANDOM_ENABLE_MOUSE
+
+# USB support
+options 	USB_DEBUG		# enable debug msgs
+device		uhci			# UHCI PCI->USB interface
+device		ohci			# OHCI PCI->USB interface
+device		ehci			# EHCI PCI->USB interface (USB 2.0)
+device		xhci			# XHCI PCI->USB interface (USB 3.0)
+device		usb			# USB Bus (required)
+device		usbhid			# USB HID Transport
+device		hkbd			# HID Keyboard
+device		ukbd			# USB Keyboard
+device		umass			# Disks/Mass storage - Requires scbus and da
+
+# Sound support
+device		sound			# Generic sound driver (required)
+device		snd_cmi			# CMedia CMI8338/CMI8738
+device		snd_csa			# Crystal Semiconductor CS461x/428x
+device		snd_emu10kx		# Creative SoundBlaster Live! and Audigy
+device		snd_es137x		# Ensoniq AudioPCI ES137x
+device		snd_hda			# Intel High Definition Audio
+device		snd_ich			# Intel, NVidia and other ICH AC'97 Audio
+device		snd_via8233		# VIA VT8233x Audio
+
+# MMC/SD
+device		mmc			# MMC/SD bus
+device		mmcsd			# MMC/SD memory card
+device		sdhci			# Generic PCI SD Host Controller
+
+# VirtIO support
+device		virtio			# Generic VirtIO bus (required)
+device		virtio_pci		# VirtIO PCI device
+device		vtnet			# VirtIO Ethernet device
+device		virtio_blk		# VirtIO Block device
+device		virtio_scsi		# VirtIO SCSI device
+device		virtio_balloon		# VirtIO Memory Balloon device
+
+# Linux KVM paravirtualization support
+device		kvm_clock		# KVM paravirtual clock driver
+
+# HyperV drivers and enhancement support
+device		hyperv			# HyperV drivers
+
+# Xen HVM Guest Optimizations
+# NOTE: XENHVM depends on xenpci and xentimer.
+# They must be added or removed together.
+options 	XENHVM			# Xen HVM kernel infrastructure
+device		xenefi			# Xen EFI timer device
+device		xenpci			# Xen HVM Hypervisor services driver
+device		xentimer		# Xen x86 PV timer device
+
+# Netmap provides direct access to TX/RX rings on supported NICs
+device		netmap			# netmap(4) support
+
+# evdev interface
+options 	EVDEV_SUPPORT		# evdev support in legacy drivers
+device		evdev			# input event device support
+device		uinput			# install /dev/uinput cdev
+
+# HID support
+options 	HID_DEBUG		# enable debug msgs
+device		hid			# Generic HID support
+device		hidbus			# Generic HID Bus
+options 	IICHID_SAMPLING		# Workaround missing GPIO INTR support
+
+# EFI devices
+device		efidev			# EFI pseudo-device
+device		efirtc			# EFI RTC

--- a/sys/conf/files
+++ b/sys/conf/files
@@ -3938,6 +3938,8 @@ kern/posix4_mib.c		standard
 kern/sched_4bsd.c		optional sched_4bsd
 kern/sched_shim.c		standard
 kern/sched_ule.c		optional sched_ule
+kern/petri_global_net.c		optional sched_4bsd
+kern/sched_petri.c		optional sched_4bsd
 kern/serdev_if.m		standard
 kern/stack_protector.c		standard \
 	compile-with "${NORMAL_C:N-fstack-protector*}"

--- a/sys/kern/kern_thread.c
+++ b/sys/kern/kern_thread.c
@@ -31,6 +31,7 @@
 #include "opt_witness.h"
 #include "opt_hwpmc_hooks.h"
 #include "opt_hwt_hooks.h"
+#include "opt_sched.h"
 
 #include <sys/systm.h>
 #include <sys/asan.h>
@@ -41,6 +42,9 @@
 #include <sys/proc.h>
 #include <sys/bitstring.h>
 #include <sys/epoch.h>
+#ifdef SCHED_4BSD
+#include <sys/sched_petri.h>
+#endif
 #include <sys/rangelock.h>
 #include <sys/resourcevar.h>
 #include <sys/sdt.h>
@@ -804,6 +808,9 @@ thread_alloc(int pages)
 	kmsan_thread_alloc(td);
 	cpu_thread_alloc(td);
 	EVENTHANDLER_DIRECT_INVOKE(thread_ctor, td);
+#ifdef SCHED_4BSD
+	init_petri_thread(td);
+#endif
 	return (td);
 }
 

--- a/sys/kern/petri_global_net.c
+++ b/sys/kern/petri_global_net.c
@@ -1,0 +1,541 @@
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/cpuset.h>
+#include <sys/pcpu.h>
+#include <sys/sdt.h>
+#include <sys/smp.h>
+#include <sys/systm.h>
+#include <sys/time.h>
+#include <sys/sched_petri.h>
+
+#define	THREAD_CAN_SCHED(td, cpu)	\
+	CPU_ISSET((cpu), &(td)->td_cpuset->cs_mask)
+
+int smp_set = 0;
+int print_enabled = 1;
+int transitions_to_print = 0;
+struct petri_cpu_resource_net resource_net;
+
+SDT_PROVIDER_DEFINE(petri);
+
+SDT_PROBE_DEFINE5(petri, resource, transition, fire,
+    "struct thread *", "char *", "int", "int", "int");
+SDT_PROBE_DEFINE5(petri, resource, transition, blocked,
+    "struct thread *", "char *", "int", "int", "int");
+SDT_PROBE_DEFINE5(petri, resource, addtoqueue, policy,
+    "struct thread *", "char *", "int", "int", "int");
+SDT_PROBE_DEFINE5(petri, resource, addtoqueue, forced,
+    "struct thread *", "char *", "int", "int", "int");
+
+const int base_resource_matrix[CPU_BASE_PLACES][CPU_BASE_TRANSITIONS] = {
+	/* Base matrix. */
+	{ 1, 0, -1, 0, 0, 0, 0, -1, 0, 1 },
+	{ 1, -1, 0, 0, 0, 0, 0, -1, -1, 1 },
+	{ 0, -1, 0, 0, 1, 1, -1, 0, 0, 0 },
+	{ 0, 1, -1, -1, 0, 0, 1, 0, 0, 0 },
+	{ 0, 0, 1, 1, -1, -1, 0, 0, 0, 0 }
+};
+
+const int base_resource_inhibition_matrix[CPU_BASE_PLACES]
+    [CPU_BASE_TRANSITIONS] = {
+	/* Base inhibition matrix. */
+	{ 0, 0, 0, 1, 0, 0, 0, 0, 1, 0 },
+	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+};
+
+const char *transitions_names[] = {
+	"ADDTOQUEUE_P0",
+	"UNQUEUE_P0",
+	"EXEC_P0",
+	"EXEC_EMPTY_P0",
+	"RETURN_VOL_P0",
+	"RETURN_INVOL_P0",
+	"FROM_GLOBAL_CPU_P0",
+	"REMOVE_QUEUE_P0",
+	"REMOVE_EMPTY_QUEUE_P0",
+	"ADDTOQUEUE_FORCED_P0",
+	"ADDTOQUEUE_P1",
+	"UNQUEUE_P1",
+	"EXEC_P1",
+	"EXEC_EMPTY_P1",
+	"RETURN_VOL_P1",
+	"RETURN_INVOL_P1",
+	"FROM_GLOBAL_CPU_P1",
+	"REMOVE_QUEUE_P1",
+	"REMOVE_EMPTY_QUEUE_P1",
+	"ADDTOQUEUE_FORCED_P1",
+	"ADDTOQUEUE_P2",
+	"UNQUEUE_P2",
+	"EXEC_P2",
+	"EXEC_EMPTY_P2",
+	"RETURN_VOL_P2",
+	"RETURN_INVOL_P2",
+	"FROM_GLOBAL_CPU_P2",
+	"REMOVE_QUEUE_P2",
+	"REMOVE_EMPTY_QUEUE_P2",
+	"ADDTOQUEUE_FORCED_P2",
+	"ADDTOQUEUE_P3",
+	"UNQUEUE_P3",
+	"EXEC_P3",
+	"EXEC_EMPTY_P3",
+	"RETURN_VOL_P3",
+	"RETURN_INVOL_P3",
+	"FROM_GLOBAL_CPU_P3",
+	"REMOVE_QUEUE_P3",
+	"REMOVE_EMPTY_QUEUE_P3",
+	"ADDTOQUEUE_FORCED_P3",
+	"REMOVE_GLOBAL_QUEUE",
+	"START_SMP",
+	"THROW",
+	"QUEUE_GLOBAL"
+};
+
+const char *cpu_places_names[] = {
+	"CANTQ",
+	"QUEUE",
+	"CPU",
+	"TOEXEC",
+	"EXECUTING",
+	"SUSPENDED"
+};
+
+const int hierarchical_transitions[] = {
+	TRAN_ADDTOQUEUE,
+	TRAN_EXEC,
+	TRAN_EXEC_EMPTY,
+	TRAN_RETURN_INVOL,
+	TRAN_RETURN_VOL,
+	TRAN_REMOVE_QUEUE,
+	TRAN_REMOVE_EMPTY_QUEUE,
+	TRAN_ADDTOQUEUE_FORCED,
+	TRAN_QUEUE_GLOBAL,
+	TRAN_REMOVE_GLOBAL_QUEUE
+};
+
+const int hierarchical_corresponse[] = {
+	TRAN_ON_QUEUE,
+	TRAN_SET_RUNNING,
+	TRAN_SET_RUNNING,
+	TRAN_SWITCH_OUT,
+	TRAN_TO_WAIT_CHANNEL,
+	TRAN_REMOVE,
+	TRAN_REMOVE,
+	TRAN_ON_QUEUE,
+	TRAN_ON_QUEUE,
+	TRAN_REMOVE
+};
+
+static void resource_fire_single_transition(struct thread *pt,
+    const char *trigger,
+    int transition_index);
+static int get_automatic_transitions_sensitized(void);
+static __inline int resource_transition_base(int transition_index);
+static __inline int resource_transition_cpu(int transition_index);
+
+static __inline int
+resource_transition_base(int transition_index)
+{
+	if (transition_index >= 0 &&
+	    transition_index < (CPU_BASE_TRANSITIONS * CPU_NUMBER))
+		return (transition_index % CPU_BASE_TRANSITIONS);
+	return (transition_index);
+}
+
+static __inline int
+resource_transition_cpu(int transition_index)
+{
+	if (transition_index >= 0 &&
+	    transition_index < (CPU_BASE_TRANSITIONS * CPU_NUMBER))
+		return (transition_index / CPU_BASE_TRANSITIONS);
+	return (NOCPU);
+}
+
+int
+resource_valid_cpu(int cpu)
+{
+	return (cpu >= 0 && cpu < CPU_NUMBER);
+}
+
+int
+resource_valid_transition(int transition_index)
+{
+	return (transition_index >= 0 &&
+	    transition_index < CPU_NUMBER_TRANSITION);
+}
+
+void
+init_resource_net(void)
+{
+	int place_index, transition_index;
+	int num_cpu;
+	int num_place, num_transition;
+
+	for (num_cpu = 0; num_cpu < CPU_NUMBER; num_cpu++) {
+		for (num_place = 0; num_place < CPU_BASE_PLACES;
+		    num_place++) {
+			for (num_transition = 0;
+			    num_transition < CPU_BASE_TRANSITIONS;
+			    num_transition++) {
+				place_index = num_place +
+				    (num_cpu * CPU_BASE_PLACES);
+				transition_index = num_transition +
+				    (num_cpu * CPU_BASE_TRANSITIONS);
+				resource_net.incidence_matrix[place_index]
+				    [transition_index] =
+				    base_resource_matrix[num_place]
+				    [num_transition];
+				resource_net.inhibition_matrix[place_index]
+				    [transition_index] =
+				    base_resource_inhibition_matrix[num_place]
+				    [num_transition];
+			}
+		}
+
+		resource_net.incidence_matrix[num_cpu * CPU_BASE_PLACES]
+		    [TRAN_THROW] = -1;
+
+		if (num_cpu != 0) {
+			resource_net.mark[PLACE_CPU +
+			    (num_cpu * CPU_BASE_PLACES)] = 1;
+			resource_net.inhibition_matrix[PLACE_SMP_NOT_READY]
+			    [(num_cpu * CPU_BASE_TRANSITIONS) +
+			    TRAN_FROM_GLOBAL_CPU] = 1;
+		}
+
+		resource_net.inhibition_matrix[PLACE_SMP_NOT_READY]
+		    [(num_cpu * CPU_BASE_TRANSITIONS) + TRAN_EXEC] = 1;
+		resource_net.inhibition_matrix[PLACE_SMP_NOT_READY]
+		    [(num_cpu * CPU_BASE_TRANSITIONS) + TRAN_ADDTOQUEUE] = 1;
+		resource_net.inhibition_matrix[PLACE_SMP_NOT_READY]
+		    [(num_cpu * CPU_BASE_TRANSITIONS) +
+		    TRAN_ADDTOQUEUE_FORCED] = 1;
+	}
+
+	resource_net.incidence_matrix[PLACE_GLOBAL_QUEUE]
+	    [TRAN_REMOVE_GLOBAL_QUEUE] = -1;
+
+	resource_net.incidence_matrix[PLACE_SMP_NOT_READY]
+	    [TRAN_START_SMP] = -1;
+	resource_net.incidence_matrix[PLACE_SMP_READY][TRAN_START_SMP] = 1;
+
+	resource_net.mark[PLACE_SMP_NOT_READY] = 1;
+
+	resource_net.mark[PLACE_EXECUTING] = 1;
+
+	for (num_transition = TRAN_FROM_GLOBAL_CPU;
+	    num_transition < CPU_NUMBER_TRANSITION;
+	    num_transition += CPU_BASE_TRANSITIONS) {
+		resource_net.incidence_matrix[PLACE_GLOBAL_QUEUE]
+		    [num_transition] = -1;
+	}
+	resource_net.incidence_matrix[PLACE_GLOBAL_QUEUE]
+	    [TRAN_QUEUE_GLOBAL] = 1;
+
+	resource_net.is_automatic_transition[TRAN_THROW] = 1;
+	print_detailed_places();
+}
+
+static __inline int
+is_inhibited(int places_index, int transition_index)
+{
+	return (resource_net.inhibition_matrix[places_index]
+	    [transition_index] == 1 &&
+	    resource_net.mark[places_index] > 0);
+}
+
+static __inline int
+is_hierarchical(int transition)
+{
+	int i;
+
+	for (i = 0; i < (int)(sizeof(hierarchical_transitions) /
+	    sizeof(hierarchical_transitions[0])); i++) {
+		if (transition == hierarchical_transitions[i])
+			return (hierarchical_corresponse[i]);
+		else if (transition < TRAN_REMOVE_GLOBAL_QUEUE &&
+		    transition % CPU_BASE_TRANSITIONS ==
+		    hierarchical_transitions[i])
+			return (hierarchical_corresponse[i]);
+	}
+	return (0);
+}
+
+void
+resource_get_sensitized(void)
+{
+	int transition_index;
+
+	for (transition_index = 0; transition_index < CPU_NUMBER_TRANSITION;
+	    transition_index++) {
+		resource_net.sensitized_buffer[transition_index] =
+		    transition_is_sensitized(transition_index);
+	}
+}
+
+
+void
+resource_fire_net(const char *trigger, struct thread *pt,
+    int transition_index)
+{
+	int automatic_transition;
+
+	if (pt == NULL)
+		return;
+
+	if (!resource_valid_transition(transition_index)) {
+		panic("petri: invalid resource transition %d from %s, td %p "
+		    "tid %d lastcpu %d oncpu %d", transition_index, trigger,
+		    pt, pt->td_tid, pt->td_lastcpu, pt->td_oncpu);
+	}
+
+	if (!smp_set && smp_started) {
+		smp_set = 1;
+		resource_fire_single_transition(pt, trigger, TRAN_START_SMP);
+	}
+
+	if (transition_is_sensitized(transition_index)) {
+		resource_fire_single_transition(pt, trigger, transition_index);
+		automatic_transition = get_automatic_transitions_sensitized();
+		while (automatic_transition != -1) {
+			resource_fire_single_transition(pt, trigger,
+			    automatic_transition);
+			automatic_transition =
+			    get_automatic_transitions_sensitized();
+		}
+	} else {
+		SDT_PROBE5(petri, resource, transition, blocked, pt,
+		    trigger, transition_index,
+		    resource_transition_cpu(transition_index),
+		    PCPU_GET(cpuid));
+		print_detailed_places();
+		panic("petri: non-sensitized resource transition %s(%d) "
+		    "from %s, td %p tid %d cpu %d lastcpu %d",
+		    transitions_names[transition_index], transition_index,
+		    trigger, pt, pt->td_tid, PCPU_GET(cpuid),
+		    pt->td_lastcpu);
+	}
+}
+
+
+static void
+resource_fire_single_transition(struct thread *pt, const char *trigger,
+    int transition_index)
+{
+	int num_place;
+	int cpu;
+	int local_transition;
+
+	if (!resource_valid_transition(transition_index)) {
+		panic("petri: invalid single resource transition %d, td %p "
+		    "tid %d", transition_index, pt, pt != NULL ? pt->td_tid :
+		    -1);
+	}
+
+	for (num_place = 0; num_place < CPU_NUMBER_PLACES; num_place++) {
+		resource_net.mark[num_place] +=
+		    resource_net.incidence_matrix[num_place][transition_index];
+	}
+	local_transition = is_hierarchical(transition_index);
+	cpu = resource_transition_cpu(transition_index);
+	SDT_PROBE5(petri, resource, transition, fire, pt, trigger,
+	    transition_index, cpu, local_transition);
+	if (cpu != NOCPU) {
+		switch (resource_transition_base(transition_index)) {
+		case TRAN_ADDTOQUEUE:
+			SDT_PROBE5(petri, resource, addtoqueue, policy, pt,
+			    trigger, cpu,
+			    resource_net.mark[PLACE_QUEUE +
+			    (cpu * CPU_BASE_PLACES)],
+			    resource_net.mark[PLACE_CANTQ +
+			    (cpu * CPU_BASE_PLACES)]);
+			break;
+		case TRAN_ADDTOQUEUE_FORCED:
+			SDT_PROBE5(petri, resource, addtoqueue, forced, pt,
+			    trigger, cpu,
+			    resource_net.mark[PLACE_QUEUE +
+			    (cpu * CPU_BASE_PLACES)],
+			    resource_net.mark[PLACE_CANTQ +
+			    (cpu * CPU_BASE_PLACES)]);
+			break;
+		}
+	}
+	if (local_transition) {
+		thread_petri_fire(pt, local_transition);
+	}
+
+	if (print_enabled && transitions_to_print != 0) {
+		printf("#& %s Transition OK: %2d - Thread %2d - CPU %2d "
+		    "&#\n", transitions_names[transition_index],
+		    transition_index, pt->td_tid, PCPU_GET(cpuid));
+		transitions_to_print--;
+	}
+}
+
+static int
+get_automatic_transitions_sensitized(void)
+{
+	int num_transition;
+
+	/*
+	 * TRAN_THROW is currently the only automatic transition, but this
+	 * loop keeps the transition table extensible.
+	 */
+	for (num_transition = 0; num_transition < CPU_NUMBER_TRANSITION;
+	    num_transition++) {
+		if (resource_net.is_automatic_transition[num_transition] &&
+		    transition_is_sensitized(num_transition))
+			return (num_transition);
+	}
+
+	return (-1);
+}
+
+int
+transition_is_sensitized(int transition_index)
+{
+	int places_index;
+
+	if (!resource_valid_transition(transition_index))
+		panic("petri: invalid transition_is_sensitized index %d",
+		    transition_index);
+
+	for (places_index = 0; places_index < CPU_NUMBER_PLACES;
+	    places_index++) {
+		if ((resource_net.incidence_matrix[places_index]
+		    [transition_index] < 0 &&
+		    resource_net.incidence_matrix[places_index]
+		    [transition_index] + resource_net.mark[places_index] < 0) ||
+		    is_inhibited(places_index, transition_index))
+			return (0);
+	}
+
+	return (1);
+}
+
+int
+resource_choose_cpu(struct thread *td)
+{
+	int transition_index;
+	int best = NOCPU;
+
+	if (td->td_lastcpu != NOCPU && !resource_valid_cpu(td->td_lastcpu)) {
+		panic("petri: invalid lastcpu %d in resource_choose_cpu, td %p "
+		    "tid %d", td->td_lastcpu, td, td->td_tid);
+	}
+
+	if (td->td_lastcpu != NOCPU &&
+	    resource_valid_cpu(td->td_lastcpu) &&
+	    THREAD_CAN_SCHED(td, td->td_lastcpu) &&
+	    transition_is_sensitized(td->td_lastcpu * CPU_BASE_TRANSITIONS)) {
+		best = td->td_lastcpu;
+		return (best);
+	}
+
+	for (transition_index = TRAN_ADDTOQUEUE;
+	    transition_index < CPU_NUMBER_TRANSITION - 4;
+	    transition_index += CPU_BASE_TRANSITIONS) {
+		if (transition_is_sensitized(transition_index)) {
+			if (!THREAD_CAN_SCHED(td, transition_index /
+			    CPU_BASE_TRANSITIONS))
+				continue;
+			else {
+				best = transition_index / CPU_BASE_TRANSITIONS;
+				break;
+			}
+		}
+	}
+
+	return (best);
+}
+
+void
+resource_expulse_thread(struct thread *td, int flags)
+{
+	int transition_number;
+
+	if (!resource_valid_cpu(td->td_lastcpu)) {
+		panic("petri: invalid lastcpu %d in resource_expulse_thread, "
+		    "td %p tid %d flags %#x", td->td_lastcpu, td, td->td_tid,
+		    flags);
+	}
+
+	if (flags & (SW_VOL)) {
+		transition_number = (td->td_lastcpu * CPU_BASE_TRANSITIONS) +
+		    TRAN_RETURN_VOL;
+		(td)->td_frominh = 1;
+	} else {
+		transition_number = (td->td_lastcpu * CPU_BASE_TRANSITIONS) +
+		    TRAN_RETURN_INVOL;
+		(td)->td_frominh = 0;
+	}
+	resource_fire_net("resource_expulse_thread", td, transition_number);
+}
+
+void
+resource_execute_thread(struct thread *newtd, int cpu)
+{
+	int transition_number;
+
+	if (!resource_valid_cpu(cpu)) {
+		panic("petri: invalid cpu %d in resource_execute_thread, "
+		    "td %p tid %d", cpu, newtd, newtd != NULL ? newtd->td_tid :
+		    -1);
+	}
+
+	transition_number = (cpu * CPU_BASE_TRANSITIONS) + TRAN_EXEC;
+	if (!transition_is_sensitized(transition_number)) {
+		transition_number = (cpu * CPU_BASE_TRANSITIONS) +
+		    TRAN_EXEC_EMPTY;
+	}
+
+	resource_fire_net("resource_execute_thread", newtd, transition_number);
+}
+
+void
+resource_remove_thread(struct thread *newtd, int cpu)
+{
+	int transition_number;
+
+	if (!resource_valid_cpu(cpu)) {
+		panic("petri: invalid cpu %d in resource_remove_thread, td %p "
+		    "tid %d", cpu, newtd, newtd != NULL ? newtd->td_tid : -1);
+	}
+
+	if (transition_is_sensitized((cpu * CPU_BASE_TRANSITIONS) +
+	    TRAN_REMOVE_QUEUE))
+		transition_number = (cpu * CPU_BASE_TRANSITIONS) +
+		    TRAN_REMOVE_QUEUE;
+	else
+		transition_number = (cpu * CPU_BASE_TRANSITIONS) +
+		    TRAN_REMOVE_EMPTY_QUEUE;
+
+	resource_fire_net("resource_remove_thread", newtd, transition_number);
+}
+
+void
+print_detailed_places(void)
+{
+	int i, j;
+
+	for (i = 0; i < CPU_BASE_PLACES; i++) {
+		for (j = 0; j < CPU_NUMBER; j++) {
+			printf("\n#& %d -> %s_P%d &#",
+			    resource_net.mark[i + (j * CPU_BASE_PLACES)],
+			    cpu_places_names[i], j);
+		}
+	}
+	printf("\n#& %d -> GLOBAL_QUEUE &#",
+	    resource_net.mark[PLACE_GLOBAL_QUEUE]);
+	printf("\n#& %d -> SMP_NOT_READY &#",
+	    resource_net.mark[PLACE_SMP_NOT_READY]);
+	printf("\n#& %d -> SMP_READY &#\n", resource_net.mark[PLACE_SMP_READY]);
+}
+
+void
+set_print_transition(int number_transitions)
+{
+	transitions_to_print = number_transitions;
+}

--- a/sys/kern/sched_4bsd.c
+++ b/sys/kern/sched_4bsd.c
@@ -58,6 +58,8 @@
 #include <machine/pcb.h>
 #include <machine/smp.h>
 
+#include <sys/sched_petri.h>
+
 #ifdef HWPMC_HOOKS
 #include <sys/pmckern.h>
 #endif
@@ -139,6 +141,7 @@ static void	resetpriority(struct thread *td);
 static void	resetpriority_thread(struct thread *td);
 #ifdef SMP
 static int	sched_pickcpu(struct thread *td);
+static int	sched_petrinet_pickcpu(struct thread *td);
 static int	forward_wakeup(int cpunum);
 static void	kick_other_cpu(int pri, int cpuid);
 #endif
@@ -258,6 +261,13 @@ SYSCTL_INT(_kern_sched_4bsd, OID_AUTO, followon, CTLFLAG_RW,
 	   &sched_followon, 0,
 	   "allow threads to share a quantum");
 #endif
+
+SDT_PROVIDER_DECLARE(petri);
+
+SDT_PROBE_DEFINE5(petri, sched, addtoqueue, decision, "struct thread *",
+    "int", "int", "int", "int");
+SDT_PROBE_DEFINE3(petri, sched, addtoqueue, global, "struct thread *",
+    "int", "int");
 
 static __inline void
 sched_load_add(void)
@@ -633,7 +643,7 @@ sched_4bsd_setup(void)
 	ccpu = 0.95122942450071400909 * FSCALE;	/* exp(-1/20) */
 
 	setup_runqs();
-
+	init_resource_net();
 	/* Account for thread0. */
 	sched_load_add();
 
@@ -664,6 +674,8 @@ sched_4bsd_initticks(void)
 static void
 sched_4bsd_init(void)
 {
+	int initial_mark_t0[PLACES_SIZE] = { 0, 0, 0, 1, 0 };
+	int i;
 
 	/*
 	 * Set up the scheduler specific parts of thread0.
@@ -671,6 +683,10 @@ sched_4bsd_init(void)
 	thread0.td_lock = &sched_lock;
 	td_get_sched(&thread0)->ts_slice = sched_slice;
 	mtx_init(&sched_lock, "sched lock", NULL, MTX_SPIN);
+
+	for (i = 0; i < PLACES_SIZE; i++) {
+		thread0.mark[i] = initial_mark_t0[i];
+	}
 }
 
 static void
@@ -806,7 +822,6 @@ static void
 sched_4bsd_fork_thread(struct thread *td, struct thread *childtd)
 {
 	struct td_sched *ts, *tsc;
-
 	childtd->td_oncpu = NOCPU;
 	childtd->td_lastcpu = NOCPU;
 	childtd->td_lock = &sched_lock;
@@ -1014,6 +1029,22 @@ sched_4bsd_sswitch(struct thread *td, int flags)
 	td->td_oncpu = NOCPU;
 
 	/*
+	 * Switch to the sched lock to fix things up and pick
+	 * a new thread.  Block the td_lock in order to avoid
+	 * breaking the critical path.
+	 */
+	if (td->td_lock != &sched_lock) {
+		mtx_lock_spin(&sched_lock);
+		tmtx = thread_lock_block(td);
+		mtx_unlock_spin(tmtx);
+	}
+
+	if ((td->td_flags & TDF_NOLOAD) == 0)
+		sched_load_rem();
+
+	resource_expulse_thread(td, flags);
+
+	/*
 	 * At the last moment, if this thread is still marked RUNNING,
 	 * then put it back on the run queue as it has not been suspended
 	 * or stopped or any thing else similar.  We never put the idle
@@ -1032,21 +1063,8 @@ sched_4bsd_sswitch(struct thread *td, int flags)
 		}
 	}
 
-	/* 
-	 * Switch to the sched lock to fix things up and pick
-	 * a new thread.  Block the td_lock in order to avoid
-	 * breaking the critical path.
-	 */
-	if (td->td_lock != &sched_lock) {
-		mtx_lock_spin(&sched_lock);
-		tmtx = thread_lock_block(td);
-		mtx_unlock_spin(tmtx);
-	}
-
-	if ((td->td_flags & TDF_NOLOAD) == 0)
-		sched_load_rem();
-
 	newtd = choosethread();
+	resource_execute_thread(newtd, PCPU_GET(cpuid));
 	MPASS(newtd->td_lock == &sched_lock);
 
 #if (KTR_COMPILE & KTR_SCHED) != 0
@@ -1301,6 +1319,16 @@ sched_pickcpu(struct thread *td)
 
 	return (best);
 }
+
+static int
+sched_petrinet_pickcpu(struct thread *td)
+{
+	int cpu;
+
+	mtx_assert(&sched_lock, MA_OWNED);
+	cpu = resource_choose_cpu(td);
+	return (cpu);
+}
 #endif
 
 static void
@@ -1309,9 +1337,17 @@ sched_4bsd_add(struct thread *td, int flags)
 {
 	cpuset_t tidlemsk;
 	struct td_sched *ts;
-	u_int cpu, cpuid;
+	u_int cpu = NOCPU, cpuid;
+	int add_transition;
+	int forced_addtoqueue = 0;
+	int addtoqueue_reason = PETRI_ADDQ_REASON_POLICY;
 	int forwarded = 0;
 	int single_cpu = 0;
+
+	if (td != NULL && td->td_frominh == 1) {
+		thread_petri_fire(td, TRAN_WAKEUP);
+		td->td_frominh = 0;
+	}
 
 	ts = td_get_sched(td);
 	THREAD_LOCK_ASSERT(td, MA_OWNED);
@@ -1342,7 +1378,6 @@ sched_4bsd_add(struct thread *td, int flags)
 			thread_lock_set(td, &sched_lock);
 	}
 	TD_SET_RUNQ(td);
-
 	/*
 	 * If SMP is started and the thread is pinned or otherwise limited to
 	 * a specific set of CPUs, queue the thread to a per-CPU run queue.
@@ -1354,17 +1389,54 @@ sched_4bsd_add(struct thread *td, int flags)
 	 */
 	if (smp_started && (td->td_pinned != 0 || td->td_flags & TDF_BOUND ||
 	    ts->ts_flags & TSF_AFFINITY)) {
-		if (td->td_pinned != 0)
-			cpu = td->td_lastcpu;
-		else if (td->td_flags & TDF_BOUND) {
-			/* Find CPU from bound runq. */
-			KASSERT(SKE_RUNQ_PCPU(ts),
-			    ("sched_add: bound td_sched not on cpu runq"));
+		if (td->td_pinned != 0) {
+			if (td->td_lastcpu != NOCPU)
+				cpu = td->td_lastcpu;
+			else
+				cpu = sched_pickcpu(td);
+			forced_addtoqueue = 1;
+			addtoqueue_reason = PETRI_ADDQ_REASON_PINNED;
+		} else if (td->td_flags & TDF_BOUND) {
+			/*
+			 * Find CPU from bound runq, preserving stock 4BSD
+			 * semantics.
+			 */
+			if (!SKE_RUNQ_PCPU(ts)) {
+				panic("sched_add: bound td_sched not on cpu "
+				    "runq, td %p tid %d runq %p", td,
+				    td->td_tid, ts->ts_runq);
+			}
 			cpu = ts->ts_runq - &runq_pcpu[0];
-		} else
-			/* Find a valid CPU for our cpuset */
-			cpu = sched_pickcpu(td);
+			if (!resource_valid_cpu(cpu)) {
+				panic("sched_add: invalid bound cpu %u, td %p "
+				    "tid %d", cpu, td, td->td_tid);
+			}
+			forced_addtoqueue = 1;
+			addtoqueue_reason = PETRI_ADDQ_REASON_BOUND;
+		} else {
+			/* Find a valid CPU for our cpuset. */
+			cpu = sched_petrinet_pickcpu(td);
+			if (cpu == NOCPU) {
+				cpu = sched_pickcpu(td);
+				forced_addtoqueue = 1;
+				addtoqueue_reason =
+				    PETRI_ADDQ_REASON_AFFINITY_FALLBACK;
+			}
+		}
+		if (!resource_valid_cpu(cpu)) {
+			panic("sched_add: invalid selected cpu %u, td %p "
+			    "tid %d", cpu, td, td->td_tid);
+		}
+	}
+
+	if (cpu != NOCPU) {
 		ts->ts_runq = &runq_pcpu[cpu];
+		add_transition = forced_addtoqueue ? TRAN_ADDTOQUEUE_FORCED :
+		    TRAN_ADDTOQUEUE;
+		SDT_PROBE5(petri, sched, addtoqueue, decision, td, cpu,
+		    add_transition, addtoqueue_reason, flags);
+		resource_fire_net("sched_add", td, add_transition +
+		    (cpu * CPU_BASE_TRANSITIONS));
 		single_cpu = 1;
 		CTR3(KTR_RUNQ,
 		    "sched_add: Put td_sched:%p(td:%p) on cpu%d runq", ts, td,
@@ -1373,8 +1445,10 @@ sched_4bsd_add(struct thread *td, int flags)
 		CTR2(KTR_RUNQ,
 		    "sched_add: adding td_sched:%p (td:%p) to gbl runq", ts,
 		    td);
-		cpu = NOCPU;
 		ts->ts_runq = &runq;
+		SDT_PROBE3(petri, sched, addtoqueue, global, td, flags,
+		    smp_started);
+		resource_fire_net("sched_add", td, TRAN_QUEUE_GLOBAL);
 	}
 
 	if ((td->td_flags & TDF_NOLOAD) == 0)
@@ -1385,7 +1459,7 @@ sched_4bsd_add(struct thread *td, int flags)
 
 	cpuid = PCPU_GET(cpuid);
 	if (single_cpu && cpu != cpuid) {
-	        kick_other_cpu(td->td_priority, cpu);
+		kick_other_cpu(td->td_priority, cpu);
 	} else {
 		if (!single_cpu) {
 			tidlemsk = idle_cpus_mask;
@@ -1470,8 +1544,24 @@ sched_4bsd_rem(struct thread *td)
 	if ((td->td_flags & TDF_NOLOAD) == 0)
 		sched_load_rem();
 #ifdef SMP
-	if (ts->ts_runq != &runq)
-		runq_length[ts->ts_runq - runq_pcpu]--;
+	if (ts->ts_runq != &runq) {
+		int cpu;
+
+		if (!SKE_RUNQ_PCPU(ts)) {
+			panic("sched_rem: td_sched not on cpu runq, td %p "
+			    "tid %d runq %p", td, td->td_tid, ts->ts_runq);
+		}
+		cpu = ts->ts_runq - runq_pcpu;
+		if (!resource_valid_cpu(cpu)) {
+			panic("sched_rem: invalid cpu runq %d, td %p tid %d",
+			    cpu, td, td->td_tid);
+		}
+		runq_length[cpu]--;
+		resource_remove_thread(td, cpu);
+	} else {
+		resource_fire_net("sched_rem", td,
+		    TRAN_REMOVE_GLOBAL_QUEUE);
+	}
 #endif
 	runq_remove(ts->ts_runq, td);
 	TD_SET_CAN_RUN(td);
@@ -1502,16 +1592,22 @@ sched_4bsd_choose(void)
 		     PCPU_GET(cpuid));
 		td = tdcpu;
 		rq = &runq_pcpu[PCPU_GET(cpuid)];
+
+		if (td != NULL) {
+			resource_fire_net("sched_choose", td, TRAN_UNQUEUE +
+			    (PCPU_GET(cpuid) * CPU_BASE_TRANSITIONS));
+		}
 	} else {
 		CTR1(KTR_RUNQ, "choosing td_sched %p from main runq", td);
+		resource_fire_net("sched_choose", td, TRAN_FROM_GLOBAL_CPU +
+		    (PCPU_GET(cpuid) * CPU_BASE_TRANSITIONS));
 	}
 
 #else
 	rq = &runq;
 	td = runq_choose(&runq);
 #endif
-
-	if (td) {
+	if (td != NULL) {
 #ifdef SMP
 		if (td == tdcpu)
 			runq_length[PCPU_GET(cpuid)]--;
@@ -1523,6 +1619,15 @@ sched_4bsd_choose(void)
 		    ("sched_choose: thread swapped out"));
 		return (td);
 	}
+	if (PCPU_GET(idlethread)->td_frominh == 1) {
+		thread_petri_fire(PCPU_GET(idlethread), TRAN_WAKEUP);
+		PCPU_GET(idlethread)->td_frominh = 0;
+	}
+	resource_fire_net("sched_choose", PCPU_GET(idlethread),
+	    TRAN_QUEUE_GLOBAL);
+	resource_fire_net("sched_choose", PCPU_GET(idlethread),
+	    TRAN_FROM_GLOBAL_CPU +
+	    (PCPU_GET(cpuid) * CPU_BASE_TRANSITIONS));
 	return (PCPU_GET(idlethread));
 }
 
@@ -1663,6 +1768,7 @@ sched_throw_tail(struct thread *td)
 	KASSERT(curthread->td_md.md_spinlock_count == 1, ("invalid count"));
 
 	newtd = choosethread();
+	resource_execute_thread(newtd, PCPU_GET(cpuid));
 
 #ifdef HWT_HOOKS
 	if (td)
@@ -1710,6 +1816,7 @@ sched_4bsd_throw(struct thread *td)
 	lock_profile_release_lock(&sched_lock.lock_object, true);
 	td->td_lastcpu = td->td_oncpu;
 	td->td_oncpu = NOCPU;
+	resource_expulse_thread(td, SW_VOL);
 
 	sched_throw_tail(td);
 }

--- a/sys/kern/sched_petri.c
+++ b/sys/kern/sched_petri.c
@@ -1,0 +1,123 @@
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/sched_petri.h>
+
+/*
+ * Petri thread net tables.
+ */
+const int matrix_Incidence[PLACES_SIZE][TRANSITIONS_SIZE] = {
+	{ -1, 0, 0, 0, 0, 0, 0 },
+	{ 1, -1, 0, 1, 0, 1, 1 },
+	{ 0, 1, -1, 0, 0, 0, -1 },
+	{ 0, 0, 1, -1, -1, 0, 0 },
+	{ 0, 0, 0, 0, 1, -1, 0 }
+};
+
+const int initial_mark[PLACES_SIZE] = { 0, 1, 0, 0, 0 };
+
+const char *thread_transitions_names[] = {
+	"TRAN_INIT",
+	"TRAN_ON_QUEUE",
+	"TRAN_SET_RUNNING",
+	"TRAN_SWITCH_OUT",
+	"TRAN_TO_WAIT_CHANNEL",
+	"TRAN_WAKEUP",
+	"TRAN_REMOVE"
+};
+
+const char *thread_places[] = {
+	"INACTIVE", "CAN_RUN", "RUNQ", "RUNNING", "INHIBITED",
+};
+
+const char *thread_state_to_string[] = {
+	"INACTIVE", "INHIBITED", "CAN_RUN", "RUNQ", "RUNNING",
+};
+
+static __inline int
+thread_valid_transition(int transition_index)
+{
+	return (transition_index >= 0 &&
+	    transition_index < TRANSITIONS_SIZE);
+}
+
+
+void
+init_petri_thread(struct thread *pt_thread)
+{
+	int i;
+
+	for (i = 0; i < PLACES_SIZE; i++) {
+		pt_thread->mark[i] = initial_mark[i];
+	}
+	pt_thread->td_frominh = 0;
+}
+
+void
+thread_get_sensitized(struct thread *pt)
+{
+	int k;
+
+	for (k = 0; k < TRANSITIONS_SIZE; k++) {
+		if (thread_transition_is_sensitized(pt, k))
+			pt->sensitized_buffer[k] = 1;
+		else
+			pt->sensitized_buffer[k] = 0;
+	}
+}
+
+int
+thread_transition_is_sensitized(struct thread *pt, int transition_index)
+{
+	int places_index;
+
+	if (pt == NULL)
+		panic("petri thread: null thread in transition_is_sensitized");
+	if (!thread_valid_transition(transition_index)) {
+		panic("petri thread: invalid transition index %d, td %p",
+		    transition_index, pt);
+	}
+
+	for (places_index = 0; places_index < PLACES_SIZE;
+	    places_index++) {
+		if (matrix_Incidence[places_index][transition_index] < 0 &&
+		    matrix_Incidence[places_index][transition_index] +
+		    pt->mark[places_index] < 0)
+			return (0);
+	}
+
+	return (1);
+
+}
+
+void
+thread_print_detailed_places(struct thread *pt)
+{
+	int i;
+
+	for (i = 0; i < PLACES_SIZE; i++)
+		printf("#& %d -> %s &#\n", pt->mark[i], thread_places[i]);
+}
+
+void
+thread_petri_fire(struct thread *pt, int transition)
+{
+	int i;
+
+	if (pt == NULL)
+		panic("petri thread: null thread in thread_petri_fire");
+	if (!thread_valid_transition(transition)) {
+		panic("petri thread: invalid fire transition %d, td %p tid %d "
+		    "state %d", transition, pt, pt->td_tid, pt->td_state);
+	}
+
+	if (thread_transition_is_sensitized(pt, transition)) {
+		for (i = 0; i < PLACES_SIZE; i++)
+			pt->mark[i] += matrix_Incidence[i][transition];
+		} else {
+			thread_print_detailed_places(pt);
+			panic("petri thread: non-sensitized transition %s(%d), "
+			    "td %p tid %d state %d",
+			    thread_transitions_names[transition], transition,
+			    pt, pt->td_tid, pt->td_state);
+		}
+}

--- a/sys/sys/proc.h
+++ b/sys/sys/proc.h
@@ -227,6 +227,26 @@ struct rusage_ext {
 };
 
 /*
+ * Definitions of transitions and places for the per-thread Petri net.
+ */
+#define PLACE_INACTIVE 0
+#define PLACE_CAN_RUN 1
+#define PLACE_CPU_RUN_QUEUE 2
+#define PLACE_RUNNING 3
+#define PLACE_INHIBITED 4
+
+#define TRAN_INIT 0
+#define TRAN_ON_QUEUE 1
+#define TRAN_SET_RUNNING 2
+#define TRAN_SWITCH_OUT 3
+#define TRAN_TO_WAIT_CHANNEL 4
+#define TRAN_WAKEUP 5
+#define TRAN_REMOVE 6
+
+#define PLACES_SIZE 5
+#define TRANSITIONS_SIZE 7
+
+/*
  * Kernel runnable context (thread).
  * This is what is put to sleep and reactivated.
  * Thread context.  Processes may have multiple threads.
@@ -392,6 +412,9 @@ struct thread {
 #ifdef EPOCH_TRACE
 	SLIST_HEAD(, epoch_tracker) td_epochs;
 #endif
+	int		td_frominh;	/* Thread comes from inhibited state. */
+	int mark[PLACES_SIZE];
+	int sensitized_buffer[TRANSITIONS_SIZE];
 };
 
 struct thread0_storage {

--- a/sys/sys/sched_petri.h
+++ b/sys/sys/sched_petri.h
@@ -1,0 +1,80 @@
+#ifndef SCHED_PETRI_H
+#define SCHED_PETRI_H
+
+#include <sys/param.h>
+#include <sys/proc.h>
+
+#define CPU_NUMBER 4
+/* Global transitions. */
+#define CPU_BASE_PLACES 5
+#define CPU_BASE_TRANSITIONS 10
+#define CPU_NUMBER_PLACES ((CPU_BASE_PLACES * CPU_NUMBER) + 3)
+#define CPU_NUMBER_TRANSITION ((CPU_BASE_TRANSITIONS * CPU_NUMBER) + 4)
+/* Definitions of transition and places for the CPU resource net */
+/* Places. */
+#define PLACE_CANTQ 0
+#define PLACE_QUEUE 1
+#define PLACE_CPU 2
+#define PLACE_TOEXEC 3
+#define PLACE_EXECUTING 4
+
+/* Global queue independent of the number of CPUs. */
+#define PLACE_GLOBAL_QUEUE (CPU_NUMBER_PLACES - 3)
+#define PLACE_SMP_NOT_READY (CPU_NUMBER_PLACES - 2)
+#define PLACE_SMP_READY (CPU_NUMBER_PLACES - 1)
+
+/* Per-CPU transitions. */
+#define TRAN_ADDTOQUEUE 0
+#define TRAN_UNQUEUE 1
+#define TRAN_EXEC 2
+#define TRAN_EXEC_EMPTY 3
+#define TRAN_RETURN_VOL 4
+#define TRAN_RETURN_INVOL 5
+#define TRAN_FROM_GLOBAL_CPU 6
+#define TRAN_REMOVE_QUEUE 7
+#define TRAN_REMOVE_EMPTY_QUEUE 8
+#define TRAN_ADDTOQUEUE_FORCED 9
+
+/* Global transitions. */
+#define TRAN_REMOVE_GLOBAL_QUEUE (CPU_NUMBER_TRANSITION - 4)
+#define TRAN_START_SMP (CPU_NUMBER_TRANSITION - 3)
+#define TRAN_THROW (CPU_NUMBER_TRANSITION - 2)
+#define TRAN_QUEUE_GLOBAL (CPU_NUMBER_TRANSITION - 1)
+
+#define PETRI_ADDQ_REASON_POLICY 0
+#define PETRI_ADDQ_REASON_PINNED 1
+#define PETRI_ADDQ_REASON_BOUND 2
+#define PETRI_ADDQ_REASON_AFFINITY_FALLBACK 3
+
+struct petri_cpu_resource_net {
+	int mark[CPU_NUMBER_PLACES];
+	int sensitized_buffer[CPU_NUMBER_TRANSITION];
+	int cpu_owner_list[CPU_NUMBER];
+	char incidence_matrix[CPU_NUMBER_PLACES][CPU_NUMBER_TRANSITION];
+	char inhibition_matrix[CPU_NUMBER_PLACES][CPU_NUMBER_TRANSITION];
+	int is_automatic_transition[CPU_NUMBER_TRANSITION];
+};
+
+/* Petri thread methods. */
+void init_petri_thread(struct thread *pt_thread);
+void thread_get_sensitized(struct thread *pt);
+int thread_transition_is_sensitized(struct thread *pt, int transition_index);
+void thread_petri_fire(struct thread *pt, int transition);
+void thread_print_detailed_places(struct thread *pt);
+
+/* Petri global methods. */
+void init_resource_net(void);
+void resource_get_sensitized(void);
+void resource_fire_net(const char *trigger, struct thread *pt,
+    int transition_index);
+int transition_is_sensitized(int transition_index);
+int resource_valid_cpu(int cpu);
+int resource_valid_transition(int transition_index);
+int resource_choose_cpu(struct thread *td);
+void resource_expulse_thread(struct thread *td, int flags);
+void resource_execute_thread(struct thread *newtd, int cpu);
+void resource_remove_thread(struct thread *newtd, int cpu);
+void print_detailed_places(void);
+void set_print_transition(int transitions_to_print);
+
+#endif

--- a/tools/sched/petri_addtoqueue.d
+++ b/tools/sched/petri_addtoqueue.d
@@ -1,0 +1,157 @@
+#!/usr/sbin/dtrace -s
+
+/*
+ * Summarize Petri scheduler enqueue decisions and fired transitions.
+ *
+ * Usage:
+ *     # kldload dtraceall
+ *     # dtrace -l -P petri
+ *     # ./tools/sched/petri_addtoqueue.d
+ *
+ * Run the workload in another terminal and stop this script with Ctrl-C.
+ */
+
+#pragma D option quiet
+#pragma D option dynvarsize=16m
+
+dtrace:::BEGIN
+{
+	policy_decisions = 0;
+	forced_decisions = 0;
+	forced_pinned = 0;
+	forced_bound = 0;
+	forced_affinity_fallback = 0;
+	global_decisions = 0;
+	policy_fired = 0;
+	forced_fired = 0;
+	blocked_total = 0;
+
+	printf("Tracing Petri addtoqueue probes. Press Ctrl-C to summarize.\n");
+}
+
+petri:sched:addtoqueue:decision
+{
+	@decisions[
+	    args[3] == 1 ? "pinned" :
+	    args[3] == 2 ? "bound" :
+	    args[3] == 3 ? "affinity-fallback" : "policy",
+	    args[1],
+	    args[2]] = count();
+
+	policy_decisions += args[3] == 0 ? 1 : 0;
+	forced_decisions += args[3] != 0 ? 1 : 0;
+	forced_pinned += args[3] == 1 ? 1 : 0;
+	forced_bound += args[3] == 2 ? 1 : 0;
+	forced_affinity_fallback += args[3] == 3 ? 1 : 0;
+}
+
+petri:sched:addtoqueue:global
+{
+	@global[args[2] ? "smp-started" : "smp-not-started"] = count();
+	global_decisions++;
+}
+
+petri:resource:addtoqueue:policy
+{
+	@fired["policy", args[2]] = count();
+	@queue_after["policy", args[2], args[3]] = count();
+	@cantq_after["policy", args[2], args[4]] = count();
+
+	policy_fired++;
+}
+
+petri:resource:addtoqueue:forced
+{
+	@fired["forced", args[2]] = count();
+	@queue_after["forced", args[2], args[3]] = count();
+	@cantq_after["forced", args[2], args[4]] = count();
+
+	forced_fired++;
+}
+
+petri:resource:transition:blocked
+{
+	@blocked[args[2], args[3], args[4]] = count();
+	blocked_total++;
+}
+
+dtrace:::END
+/(policy_decisions + forced_decisions + global_decisions) > 0/
+{
+	this->total = policy_decisions + forced_decisions + global_decisions;
+
+	printf("\nPetri sched_add decision totals:\n");
+	printf("%24s %12s %10s\n", "kind", "count", "percent");
+	printf("%24s %12d %7d.%02d%%\n", "QUEUE_GLOBAL",
+	    global_decisions, (global_decisions * 100) / this->total,
+	    ((global_decisions * 10000) / this->total) % 100);
+	printf("%24s %12d %7d.%02d%%\n", "ADDTOQUEUE_POLICY",
+	    policy_decisions, (policy_decisions * 100) / this->total,
+	    ((policy_decisions * 10000) / this->total) % 100);
+	printf("%24s %12d %7d.%02d%%\n", "ADDTOQUEUE_FORCED",
+	    forced_decisions, (forced_decisions * 100) / this->total,
+	    ((forced_decisions * 10000) / this->total) % 100);
+	printf("%24s %12d %7s\n", "TOTAL", this->total, "100.00%");
+}
+
+dtrace:::END
+/(policy_decisions + forced_decisions + global_decisions) == 0/
+{
+	printf("\nPetri sched_add decision totals:\n");
+	printf("No sched_add enqueue decisions captured.\n");
+}
+
+dtrace:::END
+/forced_decisions > 0/
+{
+	printf("\nPetri forced decision breakdown:\n");
+	printf("%24s %12s %18s\n", "reason", "count", "percent_of_forced");
+	printf("%24s %12d %15d.%02d%%\n", "pinned",
+	    forced_pinned, (forced_pinned * 100) / forced_decisions,
+	    ((forced_pinned * 10000) / forced_decisions) % 100);
+	printf("%24s %12d %15d.%02d%%\n", "bound",
+	    forced_bound, (forced_bound * 100) / forced_decisions,
+	    ((forced_bound * 10000) / forced_decisions) % 100);
+	printf("%24s %12d %15d.%02d%%\n", "affinity-fallback",
+	    forced_affinity_fallback,
+	    (forced_affinity_fallback * 100) / forced_decisions,
+	    ((forced_affinity_fallback * 10000) / forced_decisions) % 100);
+}
+
+dtrace:::END
+/(policy_fired + forced_fired) > 0/
+{
+	this->total = policy_fired + forced_fired;
+
+	printf("\nPetri addtoqueue fired totals:\n");
+	printf("%24s %12s %10s\n", "kind", "count", "percent");
+	printf("%24s %12d %7d.%02d%%\n", "ADDTOQUEUE_POLICY",
+	    policy_fired, (policy_fired * 100) / this->total,
+	    ((policy_fired * 10000) / this->total) % 100);
+	printf("%24s %12d %7d.%02d%%\n", "ADDTOQUEUE_FORCED",
+	    forced_fired, (forced_fired * 100) / this->total,
+	    ((forced_fired * 10000) / this->total) % 100);
+	printf("%24s %12d %7s\n", "TOTAL", this->total, "100.00%");
+	printf("%24s %12d\n", "BLOCKED_TRANSITIONS", blocked_total);
+}
+
+dtrace:::END
+{
+	printf("\nPetri sched_add decisions by reason, target CPU and transition:\n");
+	printa("%20s cpu=%d transition=%d %@d\n", @decisions);
+
+	printf("\nPetri global queue enqueues:\n");
+	printa("%20s %@d\n", @global);
+
+	printf("\nPetri addtoqueue transitions fired by kind and CPU:\n");
+	printa("%20s cpu=%d %@d\n", @fired);
+
+	printf("\nPetri queue mark after addtoqueue by kind, CPU and mark:\n");
+	printa("%20s cpu=%d queue_mark=%d %@d\n", @queue_after);
+
+	printf("\nPetri CANTQ mark after addtoqueue by kind, CPU and mark:\n");
+	printa("%20s cpu=%d cantq_mark=%d %@d\n", @cantq_after);
+
+	printf("\nBlocked Petri transitions by transition, target CPU and running CPU:\n");
+	printa("transition=%d target_cpu=%d running_cpu=%d %@d\n", @blocked);
+}


### PR DESCRIPTION
## Summary
- Port the base Petri-net scheduler prototype onto current FreeBSD main.
- Keep GENERIC unchanged and add PI_KERNELCONF from current GENERIC with SCHED_4BSD selected and extra diagnostics.
- Add Petri thread/global resource nets, scheduler integration, and DTrace probes for add-to-queue decisions.

## Main-port notes
- origin/main was fast-forwarded to upstream/main before this branch was rebuilt.
- Current main centralizes sched provider/probe definitions in sched_shim.c, so sched_4bsd.c only declares/adds Petri-specific probes.
- sched_throw_tail now updates the Petri CPU resource net before cpu_throw(), while preserving the HWT hooks from main.
- Diagnostics are DTrace probes and do not log unless enabled by the caller.

## Validation
- git diff --cached --check before commit
- no kernel build run yet